### PR TITLE
Rpy2 fix

### DIFF
--- a/mvpa/clfs/enet.py
+++ b/mvpa/clfs/enet.py
@@ -19,6 +19,8 @@ import mvpa.base.externals as externals
 if externals.exists('elasticnet', raise_=True):
     import rpy2.robjects
     import rpy2.robjects.numpy2ri
+    if hasattr(rpy2.robjects.numpy2ri,'activate'):
+        rpy2.robjects.numpy2ri.activate()
     RRuntimeError = rpy2.robjects.rinterface.RRuntimeError
     r = rpy2.robjects.r
     r.library('elasticnet')

--- a/mvpa/clfs/glmnet.py
+++ b/mvpa/clfs/glmnet.py
@@ -19,6 +19,8 @@ import mvpa.base.externals as externals
 if externals.exists('glmnet', raise_=True):
     import rpy2.robjects
     import rpy2.robjects.numpy2ri
+    if hasattr(rpy2.robjects.numpy2ri,'activate'):
+        rpy2.robjects.numpy2ri.activate()
     RRuntimeError = rpy2.robjects.rinterface.RRuntimeError
     r = rpy2.robjects.r
     r.library('glmnet')

--- a/mvpa/clfs/lars.py
+++ b/mvpa/clfs/lars.py
@@ -19,6 +19,8 @@ import mvpa.base.externals as externals
 if externals.exists('lars', raise_=True):
     import rpy2.robjects
     import rpy2.robjects.numpy2ri
+    if hasattr(rpy2.robjects.numpy2ri,'activate'):
+        rpy2.robjects.numpy2ri.activate()
     RRuntimeError = rpy2.robjects.rinterface.RRuntimeError
     r = rpy2.robjects.r
     r.library('lars')

--- a/mvpa/clfs/mass.py
+++ b/mvpa/clfs/mass.py
@@ -26,6 +26,8 @@ from mvpa.base.learner import FailedToTrainError, FailedToPredictError
 if externals.exists('mass', raise_=True):
     import rpy2.robjects
     import rpy2.robjects.numpy2ri
+    if hasattr(rpy2.robjects.numpy2ri,'activate'):
+        rpy2.robjects.numpy2ri.activate()
     RRuntimeError = rpy2.robjects.rinterface.RRuntimeError
     r = rpy2.robjects.r
     r.library('MASS')


### PR DESCRIPTION
Howdy folks:

This minor change is to call activate() if it is available after the rpy2.robjects.numpy2ri import.  On the latest version of RPy2 this is required for this interface to work.

Best,
Per
