### PR TITLE
NF: add a .mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,8 @@
+Yaroslav Halchenko <debian@onerussian.com>
+Yaroslav Halchenko <git@onerussian.com>
+Per B. Sederberg <psederberg@gmail.com>
+Per B. Sederberg <per@parsec.Princeton.EDU>
+Scott Gorlin <gorlins@mit.edu>
+Scott Gorlin <scott@nlinfit.(none)>
+Swaroop Guntupalli <swaroopgj@gmail.com>
+Swaroop Guntupalli <swaroop@mvpa-linux.(none)>


### PR DESCRIPTION
The .mailmap file allows to map names to emails to remove duplicates from the
output of 'git shortlog'

before:

  3169  Yaroslav Halchenko
  2384  Michael Hanke
   175  Emanuele Olivetti
   150  Per B. Sederberg
    47  Per Sederberg
    39  Scott Gorlin
    30  Valentin Haenel
    19  Swaroop Guntupalli
    14  Yaroslav O. Halchenko
     8  Ingo Fründ
     7  Tiziano Zito
     2  James Kyle
     2  James M. Hughes
     2  Matthias
     2  Michael W. Cole
     2  Russell Poldrack
     2  Scott
     1  Florian Baumgartner
     1  Geethapriya Raghavan
     1  NIPY Developers
     1  Neukom Institute
     1  Rajeev Raizada
     1  Satrajit Ghosh
     1  swaroop

withe the new mailmap file:

  3183  Yaroslav Halchenko
  2384  Michael Hanke
   197  Per B. Sederberg
   175  Emanuele Olivetti
    41  Scott Gorlin
    31  Valentin Haenel
    20  Swaroop Guntupalli
     8  Ingo Fründ
     7  Tiziano Zito
     2  James Kyle
     2  James M. Hughes
     2  Matthias
     2  Michael W. Cole
     2  Russell Poldrack
     1  Florian Baumgartner
     1  Geethapriya Raghavan
     1  NIPY Developers
     1  Neukom Institute
     1  Rajeev Raizada
     1  Satrajit Ghosh

I have an additional commit obviously, since i added the .mailmap file.
