### PR TITLE
ENH: maintain GLM wrapper + enhance set of reported statistics with zstat

### DIFF
--- a/mvpa2/measures/statsmodels_adaptor.py
+++ b/mvpa2/measures/statsmodels_adaptor.py
@@ -15,6 +15,10 @@ import numpy as np
 from mvpa2.base import externals
 
 # do conditional to be able to build module reference
+if externals.exists('scipy', raise_=True):
+    from mvpa2.support.stats import scipy
+    import scipy.stats as stats
+
 if externals.exists('statsmodels', raise_=True):
     import statsmodels.api as sm
 
@@ -127,25 +131,25 @@ class UnivariateStatsModels(FeaturewiseMeasure):
         Parameters
         ----------
         exog : array-like
-            Column ordered (observations in rows) design matrix.
+          Column ordered (observations in rows) design matrix.
         model_gen : callable
-            Callable that returns a StatsModels model when called like
-            ``model_gen(endog, exog)``.
+          Callable that returns a StatsModels model when called like
+          ``model_gen(endog, exog)``.
         res : {'params', 'tvalues', ...} or 1d array or 2d array or callable
           Variable of interest that should be reported as feature-wise
           measure. If a str, the corresponding attribute of the model fit result
           class is returned (e.g. 'tvalues'). If a 1d-array, it is passed
           to the fit result class' ``t_test()`` function as a t-contrast vector.
           If a 2d-array, it is passed to the ``f_test()`` function as a
-          contrast matrix. If both latter cases a number of common test
-          statistics are return in the rows of the result dataset. A description
+          contrast matrix.  In both latter cases a number of common test
+          statistics are returned in the rows of the result dataset. A description
           is available in the 'descr' sample attribute. Any other datatype
           passed to this argument will be treated as a callable, the model
           fit result is passed to it, and its return value(s) is aggregated
           in the result dataset.
-        add_constant : bool
-            If True, a constant will be added to the design matrix that is
-            passed to ``exog``.
+        add_constant : bool, optional
+          If True, a constant will be added to the design matrix that is
+          passed to ``exog``.
         """
         FeaturewiseMeasure.__init__(self, **kwargs)
         self._exog = exog
@@ -161,13 +165,17 @@ class UnivariateStatsModels(FeaturewiseMeasure):
         """Helper for apply_along_axis()"""
         res = self._res
         results = self._model_gen(Y, self._exog).fit()
+        t_to_z = lambda t, df: stats.norm.ppf(stats.t.cdf(t, df))
         if isinstance(res, np.ndarray):
             if len(res.shape) == 1:
                 tstats = results.t_test(self._res)
                 return [np.asscalar(i) for i in [tstats.tvalue,
                                                  tstats.pvalue,
                                                  tstats.effect,
-                                                 tstats.sd]] + [tstats.df_denom]
+                                                 tstats.sd,
+                                                 np.array(tstats.df_denom),
+                                                 t_to_z(tstats.tvalue, tstats.df_denom)]]
+
             elif len(res.shape) == 2:
                 fstats = results.f_test(self._res)
                 return [np.asscalar(i) for i in
@@ -190,7 +198,7 @@ class UnivariateStatsModels(FeaturewiseMeasure):
         res = self._res
         if isinstance(res, np.ndarray):
             if len(res.shape) == 1:
-                sa = ['tvalue', 'pvalue', 'effect', 'sd', 'df']
+                sa = ['tvalue', 'pvalue', 'effect', 'sd', 'df', 'zvalue']
             elif len(res.shape) == 2:
                 sa = ['fvalue', 'pvalue', 'df_num', 'df_denom']
         elif isinstance(res, str):
@@ -210,14 +218,9 @@ class GLM(UnivariateStatsModels):
     class.
     """
     def __init__(self, design, voi='pe', **kwargs):
-        import warnings
-        warnings.warn("The 'GLM' class is deprecated. Please migrate to UnivariateStatsModels",
-                      DeprecationWarning)
-        if voi == 'pe':
-            voi = 'params'
-        elif voi == 'zstat':
-            raise ValueError("GLM class no longer supports 'zstat' reports."
-                             " Please migrate to UnivariateStatsModels and tvalues.")
+        if isinstance(voi, str):
+            # Possibly remap to adjusted interface
+            voi = {'pe': 'params', 'zstat': 'zvalue'}.get(voi, voi)
         UnivariateStatsModels.__init__(
                               self,
                               design,

--- a/mvpa2/tests/test_stats_sp.py
+++ b/mvpa2/tests/test_stats_sp.py
@@ -391,7 +391,7 @@ class StatsTestsScipy(unittest.TestCase):
         glm = GLM(X, voi=[1, 0])
         contrast = glm(data)
         assert_array_almost_equal(contrast.samples[0], tstats.samples[0])
-        assert_equals(len(contrast), 5)
+        assert_equals(len(contrast), 6)
         # we should be able to recover the approximate effect size of the signal
         # which is constructed with a baseline offset of 2 (see above)
         if cfg.getboolean('tests', 'labile', default='yes'):


### PR DESCRIPTION
Added zstat at the end of the 'list' to maintain compatibility

While at it I wonder
- shouldn't this be implemented as Learner where in _train it fits the model and in forward implements contrasts provided in input dataset?
- now it mixes what to do (just fit, contrast) with what to output (params, tvalues, bunch of contrast stats) in a single option (res).  Should it may be separate those apart and allow for multiple contrasts to be output for a single model fit? e.g.

`t={'F>C': [0,1], 'C>F': [1, 0]}, F={'F|C', [[1, 1]]}`

with default (empty) res would produce a dataset with samples containing all gory details (estimates, ttest, contrast stats) with "test" and "descr" containing description of what each sample is?

and then `res` could be specified to point which samples to output, or may be we could/should get a generic Mapper which select samples based on specification (pretty much to replace good old PyMVPA 0.4 Dataset.select or whatever it was called)?
