### PR TITLE
BF(DOC): list values of 'string' choices in Parameter's

### DIFF
--- a/mvpa2/base/param.py
+++ b/mvpa2/base/param.py
@@ -154,7 +154,13 @@ class Parameter(IndexedCollectable):
         paramsdoc = [paramsdoc]
         try:
             doc = self.__doc__.strip()
-            if not doc.endswith('.'): doc += '.'
+            if not doc.endswith('.'):
+                doc += '.'
+            if hasattr(self, 'choices') \
+              and ((hasattr(self, 'allowedtype') and 'string' in self.allowedtype)
+                   or np.all([isinstance(x, basestring) for x in self.choices])):
+                choices = ', '.join(repr(x) for x in self.choices)
+                doc += " [Choices: %s]" % choices
             try:
                 doc += " (Default: %r)" % (self.default,)
             except:


### PR DESCRIPTION
with such changes `choices` provided to a Parameter would be included into a docstring

```
$> PYTHONPATH=$PWD python -c 'from mvpa2.clfs.gda import LDA; print LDA.__init__.__doc__'                   
Initialize a GDA classifier.


Parameters
----------
prior
  How to compute prior distribution. [Choices: 'laplacian_smoothing',
  'uniform', 'ratio'] (Default: 'laplacian_smoothing')
allow_pinv
...
```
