### PR TITLE
NF: Draft of export/import functionality for long-term dataset storage

### DIFF
--- a/mvpa2/datasets/base.py
+++ b/mvpa2/datasets/base.py
@@ -519,3 +519,25 @@ class HollowSamples(object):
     def view(self):
         """Return itself"""
         return self
+
+
+def ds2npz(filename, ds, compressed=True):
+    """Convert a dataset into NumPy's NPZ format for permanent storage"""
+    content = {}
+    content['samples'] = ds.samples
+    for cid, col in (('sa::', ds.sa), ('fa::', ds.fa)):
+        for attr in col:
+            content[cid + attr] = col[attr].value
+    if compressed:
+        savefx = np.savez_compressed
+    else:
+        savefx = np.savez
+    savefx(filename, **content)
+
+def npz2ds(filename):
+    """Load a dataset from NumPy's NPZ format"""
+    content = np.load(filename)
+    sa = dict([(c[4:], content[c]) for c in content if c.startswith('sa::')])
+    fa = dict([(c[4:], content[c]) for c in content if c.startswith('fa::')])
+    ds = AttrDataset(content['samples'], sa=sa, fa=fa)
+    return ds

--- a/mvpa2/tests/test_datasetng.py
+++ b/mvpa2/tests/test_datasetng.py
@@ -23,7 +23,8 @@ from mvpa2.base.types import is_datasetlike
 from mvpa2.base.dataset import DatasetError, vstack, hstack, all_equal, \
                                 stack_by_unique_feature_attribute, \
                                 stack_by_unique_sample_attribute
-from mvpa2.datasets.base import dataset_wizard, Dataset, HollowSamples
+from mvpa2.datasets.base import dataset_wizard, Dataset, HollowSamples, \
+                                ds2npz, npz2ds
 from mvpa2.misc.data_generators import normal_feature_dataset
 from mvpa2.testing import reseed_rng
 import mvpa2.support.copy as copy
@@ -997,6 +998,21 @@ def test_h5py_io(dsfile):
         #assert_equal('#'.join(repr(ds.a.mapper).split('#')[:-1]),
         #             '#'.join(repr(ds2.a.mapper).split('#')[:-1]))
         pass
+
+@with_tempfile(suffix='.npz')
+def test_npzexport(npzfile):
+    # store random dataset to file
+    ds = datasets['3dlarge']
+    ds2npz(npzfile, ds)
+    # reload and check for identity
+    ds2 = npz2ds(npzfile)
+    assert_array_equal(ds.samples, ds2.samples)
+    for attr in ds.sa:
+        assert_array_equal(ds.sa[attr].value, ds2.sa[attr].value)
+    for attr in ds.fa:
+        assert_array_equal(ds.fa[attr].value, ds2.fa[attr].value)
+    # there is no mapper in this storage format
+    assert_false('mapper' in ds2.a)
 
 
 def test_all_equal():


### PR DESCRIPTION
This is not complete -- a proposal for discussion.

Idea: With our serialization magic, h5save() is not a good format approach for storing a dataset in the long-term.
This proposal provides two functions that can load/save datasets into NumPy's NPZ format (compressed/uncompressed). Naturally only samples, sa and fa collections are stored, hence no mappers or other attributes.

Documentation will be completed once discussed.
