### PR TITLE
RF: rename command pytest to eval.  Closes #180

### DIFF
--- a/bin/pymvpa2
+++ b/bin/pymvpa2
@@ -38,7 +38,7 @@ enabled_cmds = [
   'searchlight',
   'select',
   'atlaslabeler',
-  'pytest'
+  'eval'
 ]
 
 # what version are we talking

--- a/doc/examples/cmdline/datasets.sh
+++ b/doc/examples/cmdline/datasets.sh
@@ -58,8 +58,8 @@ pymvpa2 mkevds --csv-events  "$outdir"/events.csv --onset-column vol \
 
 # EXAMPLE END
 
-pymvpa2 pytest -i "$outdir"/evds.hdf5 -e 'assert(len(dss[0]) == 3)'
-pymvpa2 pytest -i "$outdir"/short_ds.hdf5 -e 'assert(len(dss[0]) == 500)'
+pymvpa2 eval -i "$outdir"/evds.hdf5 -e 'assert(len(dss[0]) == 3)'
+pymvpa2 eval -i "$outdir"/short_ds.hdf5 -e 'assert(len(dss[0]) == 500)'
 
 # cleanup if working in tmpdir
 [ $have_tmpdir = 1 ] && rm -rf $outdir || true

--- a/doc/examples/cmdline/fmri_analyses.sh
+++ b/doc/examples/cmdline/fmri_analyses.sh
@@ -115,8 +115,8 @@ done
 
 # EXAMPLE END
 
-#pymvpa2 pytest -i "$outdir"/evds.hdf5 -e 'assert(len(dss[0]) == 3)'
-#pymvpa2 pytest -i "$outdir"/short_ds.hdf5 -e 'assert(len(dss[0]) == 500)'
+#pymvpa2 eval -i "$outdir"/evds.hdf5 -e 'assert(len(dss[0]) == 3)'
+#pymvpa2 eval -i "$outdir"/short_ds.hdf5 -e 'assert(len(dss[0]) == 500)'
 
 # cleanup if working in tmpdir
 [ $have_tmpdir = 1 ] && rm -rf $outdir || true

--- a/doc/examples/cmdline/preproc.sh
+++ b/doc/examples/cmdline/preproc.sh
@@ -37,7 +37,7 @@ pymvpa2 preproc --filter-passband 0.005 0.067 \
 # EXAMPLE END
 
 # check that the filtered dataset actually has the low freqs removed
-pymvpa2 pytest -i "$outdir"/bold_ds.hdf5 \
+pymvpa2 eval -i "$outdir"/bold_ds.hdf5 \
                -i "$outdir"/spec_filtered.hdf5 \
                -e 'assert np.all(np.fft.fft(dss[0][:,0])[:3] > np.fft.fft(dss[1][:,0])[:3])'
 

--- a/doc/examples/cmdline/start_easy.sh
+++ b/doc/examples/cmdline/start_easy.sh
@@ -48,7 +48,7 @@ pymvpa2 dump -s -i "$outdir"/crossval_results.hdf5
 
 #% EXAMPLE END
 
-pymvpa2 pytest -i "$outdir"/crossval_results.hdf5 \
+pymvpa2 eval -i "$outdir"/crossval_results.hdf5 \
                -e 'assert ds.shape == (1,1)' \
                -e 'assert ds.samples[0,0] < 0.1'
 

--- a/doc/source/cmdline.rst
+++ b/doc/source/cmdline.rst
@@ -74,7 +74,7 @@ Auxilliary command
 .. toctree::
 
    generated/cmd_info
-   generated/cmd_pytest
+   generated/cmd_eval
    generated/cmd_atlaslabeler
 
 Example scripts

--- a/mvpa2/cmdline/cmd_eval.py
+++ b/mvpa2/cmdline/cmd_eval.py
@@ -28,11 +28,11 @@ Examples:
 
 Assert some condition
 
-  $ pymvpa2 pytest -e 'assert(4==4)'
+  $ pymvpa2 eval -e 'assert(4==4)'
 
 Check for the presence of a particular sample attribute in a dataset
 
-  $ pymvpa2 pytest -e 'dss[0].sa.subj3' -i mydata.hdf5
+  $ pymvpa2 eval -e 'dss[0].sa.subj3' -i mydata.hdf5
 
 """
 


### PR DESCRIPTION
As its description says -- it is about arbitrary evaluation.
Since PyMVPA is a Python module -- no need imho for py prefix
