### PR TITLE
BF: create a new copy of a Collectable if assigning with another name. Closes #149

### DIFF
--- a/mvpa2/base/collections.py
+++ b/mvpa2/base/collections.py
@@ -403,9 +403,20 @@ class Collection(dict):
                   "attribute or a method with such a name is already present " \
                   "in dict interface.  Choose some other name." % (key, self)
         if not isinstance(value, Collectable):
-            value = Collectable(value)
-        # overwrite the Collectable's name with the given one
-        value.name = key
+            value = Collectable(value, name=key)
+        else:
+            if not value.name: # None assigned -- just use the Collectable
+                value.name = key
+            elif value.name == key: # assigned the same -- use the Collectable
+                pass
+            else: # use the copy and assign new name
+                # see https://github.com/PyMVPA/PyMVPA/issues/149
+                # for the original issue.  __copy__ directly to avoid copy.copy
+                # doing the same + few more checks
+                value = value.__copy__()
+                # overwrite the Collectable's name with the given one
+                value.name = key
+
         _object_setitem(self, key, value)
 
 

--- a/mvpa2/tests/test_datasetng.py
+++ b/mvpa2/tests/test_datasetng.py
@@ -1041,3 +1041,17 @@ def test_hollow_samples():
     assert_equal(ds.samples.dtype, int)
     assert_equal(ds.shape, sshape)
 
+def test_assign_sa():
+    # https://github.com/PyMVPA/PyMVPA/issues/149
+    ds = Dataset(np.arange(6).reshape((2,-1)), sa=dict(targets=range(2)))
+    ds.sa['task'] = ds.sa['targets']
+    # so it should be a new collectable now
+    assert_equal(ds.sa['task'].name, 'task')
+    assert_equal(ds.sa['targets'].name, 'targets') # this lead to issue reported in 149
+    assert('task' in ds.sa.keys())
+    assert('targets' in ds.sa.keys())
+    ds1 = ds[:, 1]
+    assert('task' in ds1.sa.keys())
+    assert('targets' in ds1.sa.keys()) # issue reported in 149
+    assert_equal(ds1.sa['task'].name, 'task')
+    assert_equal(ds1.sa['targets'].name,'targets')


### PR DESCRIPTION
It is probably just a reflection of a "suboptimal" design where name of a collectable is a key within a Collection dictionary but also is known to the Collectable itself... this one provides a quick&dirty solution to assign a (renamed) copy of a Collectable if its original name differs from the name/key it gets assigned to.
