### PR TITLE
ENH: do allow "True" and "False" for EnsureBool

### DIFF
--- a/mvpa2/base/constraints.py
+++ b/mvpa2/base/constraints.py
@@ -125,12 +125,13 @@ class EnsureBool(Constraint):
     def __call__(self, value):
         if isinstance(value, bool):
             return value
-        elif value in ('0', 'no', 'off', 'disable', 'false'):
-            return False
-        elif value in ('1', 'yes', 'on', 'enable', 'true'):
-            return True
-        else:
-            raise ValueError("value must be converted to boolean")
+        elif isinstance(value, basestring):
+            value = value.lower()
+            if value in ('0', 'no', 'off', 'disable', 'false'):
+                return False
+            elif value in ('1', 'yes', 'on', 'enable', 'true'):
+                return True
+        raise ValueError("value must be converted to boolean")
 
     def long_description(self):
         return 'value must be convertible to type bool'

--- a/mvpa2/tests/test_constraints.py
+++ b/mvpa2/tests/test_constraints.py
@@ -47,6 +47,7 @@ class SimpleConstraintsTests(unittest.TestCase):
         assert_equal(c(True), True)
         assert_equal(c(False), False)
         # all that resuls in True
+        assert_equal(c('True'), True)
         assert_equal(c('true'), True)
         assert_equal(c('1'), True)
         assert_equal(c('yes'), True)
@@ -54,15 +55,14 @@ class SimpleConstraintsTests(unittest.TestCase):
         assert_equal(c('enable'), True)
         # all that resuls in False
         assert_equal(c('false'), False)
+        assert_equal(c('False'), False)
         assert_equal(c('0'), False)
         assert_equal(c('no'), False)
         assert_equal(c('off'), False)
         assert_equal(c('disable'), False)
         # this should always fail
-        assert_raises(ValueError, lambda: c('True'))
-        assert_raises(ValueError, lambda: c('False'))
-        assert_raises(ValueError, lambda: c(0))
-        assert_raises(ValueError, lambda: c(1))
+        assert_raises(ValueError, c, 0)
+        assert_raises(ValueError, c, 1)
 
     def test_str(self):
         c = EnsureStr()


### PR DESCRIPTION
This is how they look in Python so it is only native to state them as
such in environment variables and crash stating that True is not bool
is confusing to say the least.
