### PR TITLE
RF+MSC: switch off pickling of internal surface objects

### DIFF
--- a/mvpa2/support/nibabel/surf.py
+++ b/mvpa2/support/nibabel/surf.py
@@ -956,9 +956,20 @@ class Surface(object):
         # these are lazily computed on the first call to e.g. node2faces
         lazy_keys = ('_n2f', '_f2el', '_v2ael', '_e2f', '_nbrs')
         lazy_dict = dict()
-        for lazy_key in lazy_keys:
-            if lazy_key in self.__dict__:
-                lazy_dict[lazy_key] = self.__dict__[lazy_key]
+        # TODO: add in efficient way to translate these dictionaries
+        #       to something like a numpy array, and implement the 
+        #       translation back. Types for these dicts:
+        #       _n2f: int -> [int]
+        #       _f2el: array
+        #       _v2ael: array
+        #       _e2f: (int,int) -> int
+        #       _nbrs: int -> (int -> float)
+        #       
+        # For now this this functionaltiy is switched off,
+        # because pickling it (also with hdf5) takes a long time
+        #for lazy_key in lazy_keys:
+        #    if lazy_key in self.__dict__:
+        #        lazy_dict[lazy_key] = self.__dict__[lazy_key]
 
 
         return (self.__class__, (self._v, self._f), lazy_dict)


### PR DESCRIPTION
in the current implementation this comes with a significant speed penalty. 
TODO: see if these internal surface objects can be stored more efficiently.

Note that if these objects are ignored in **reduce**, they will be regenerated upon the first call of the respective function - which comes with quite a minor speed penalty.

@hanke and @yarikoptic, what do you think?
