### PR TITLE
ENH Add identity neighborhood

### DIFF
--- a/mvpa2/misc/neighborhood.py
+++ b/mvpa2/misc/neighborhood.py
@@ -30,6 +30,7 @@ class IdentityNeighborhood(object):
     """
 
     def __init__(self):
+        """Initialize the neighborhood"""
         pass
 
     def __repr__(self):

--- a/mvpa2/misc/neighborhood.py
+++ b/mvpa2/misc/neighborhood.py
@@ -23,6 +23,38 @@ from mvpa2.misc.support import idhash as idhash_
 if __debug__:
     from mvpa2.base import debug
 
+class IdentityNeighborhood(object):
+    """Trivial neighborhood.
+
+    Use this if you want neighbors(i) == [i]
+    """
+
+    def __init__(self):
+        pass
+
+    def __repr__(self):
+        return self.__class__.__name__
+
+    def train(self, dataset):
+        pass
+
+    def __call__(self, coordinate):
+        """Return coordinate in a list
+
+        Parameters
+        ----------
+        coordinate : sequence type of length 3 with integers
+
+        Returns
+        -------
+        [tuple(coordinate)]
+
+        """
+        # type checking
+        coordinate = np.asanyarray(coordinate)
+        return [tuple(coordinate)]
+
+
 class Sphere(object):
     """N-Dimensional hypersphere.
 

--- a/mvpa2/tests/test_neighborhood.py
+++ b/mvpa2/tests/test_neighborhood.py
@@ -29,6 +29,15 @@ def test_distances():
     assert_equal(absmin_distance(a, b), 4)
 
 
+def test_identity():
+    # IdentityNeighborhood() behaves like Sphere(0.5) without all of the
+    # computation. Test on a few different coordinates.
+    neighborhood = ne.IdentityNeighborhood()
+    sphere = ne.Sphere(0.5)
+    for center in ((0, 0, 0), (1, 1, 1), (0, 0), (0, )):
+        assert_array_equal(neighborhood(center), sphere(center))
+
+
 def test_sphere():
     # test sphere initialization
     s = ne.Sphere(1)


### PR DESCRIPTION
Neighborhood such that `neighbors(i) == [i]`.

Perhaps there already exists a way of doing this (apart from, say, `Sphere(0.5)`), but since it was easier for me to write this than dig deeper into the code, I figured it might be useful for others to have something big and obvious.