### PR TITLE
BF: rst2ipnbpy - more unique temp string for \n, fixing first_line

### DIFF
--- a/tools/rst2ipnbpy
+++ b/tools/rst2ipnbpy
@@ -28,14 +28,17 @@ def prep_rest(rest):
     # which lacks flags keyword argument for re.subn
     # We will first replace all newlines with a unique %%%
     # which we will use as a new line symbol in our expressions
-    assert(not '%%%' in rest)           # at least some checking
-    doc = rest.replace('\n', '%%%')
-    doc, _ = re.subn(r'%%%.. index.*?%%%', '', doc)
+
+    # Replace \n with some unique line which is unlikely to appear at the endof the line
+    NL = "<TEMPNEWLINE>"
+    assert(not NL in rest)           # at least some checking
+    doc = rest.replace('\n', NL)
+    doc, _ = re.subn(r'%s.. index.*?%s' % (NL, NL), '', doc)
     # fold text roles inside to turn them into a ref
     subns = 1
     while not subns == 0:
         doc, subns = re.subn(r':([a-z]+):`(.*)`', '`:\\1:\\2`', doc)
-    doc = doc.replace('%%%', '\n')      # replace %%% back
+    doc = doc.replace(NL, '\n')      # NL back
     return doc
 
 
@@ -258,6 +261,7 @@ class ReST2IPyNB(object):
                     self._parse(item.children[1])
                     self._buffer = '\n%s: %s' % (term, self._buffer)
             elif tag in ['enumerated_list', 'bullet_list']:
+                # TODO: has problems with nested lists formatting
                 self._add_markdowncell()
                 for i, item in enumerate(child.children):
                     if tag == 'enumerated_list':
@@ -286,7 +290,7 @@ class ReST2IPyNB(object):
                                  newline=True, paragraph=True)
             elif tag == 'block_quote':
                 self._flush_buffer()
-                first_line = len(self._currcell['source'])
+                first_line = len(self._currcell['source']) - 1
                 # skip the wrapping paragraph
                 self._parse(child.children[0])
                 self._flush_buffer()
@@ -310,9 +314,8 @@ class ReST2IPyNB(object):
                     self._add2buffer('# you can use this cell for this exercise\n')
                     self._add_markdowncell()
                     self._currcell['source'].append('- - -\n')
-                elif child.children[0].astext() == 'Unknown directive type "seealso".':
-                    pass
-                elif child.children[0].astext() == 'Unknown directive type "todo".':
+                elif re.match('Unknown directive type "(seealso|style|todo|layout)".',
+                              child.children[0].astext()):
                     pass
                 else:
                     raise RuntimeError("cannot handle system message '%s'"


### PR DESCRIPTION
ran into problems while trying to convert slides for Python course of Per
e.g.
http://memory.osu.edu/classes/python/_sources/lessons/lsn01.txt

Not sure if that  -1 is due, but was needed.

It also misses handling tables tags so for processing Per's lesson, just remove those tables

I wish we had tests for this beast ;)