### PR TITLE
ENH: afni_surface_alphasim: provide more informative error message 

### DIFF
--- a/mvpa2/support/afni/afni_surface_alphasim.py
+++ b/mvpa2/support/afni/afni_surface_alphasim.py
@@ -545,8 +545,6 @@ def fix_options(config):
 
 def _extension_indicates_surface_file(fn):
     surface_extensions=['.gii','.niml.dset','.1D','.1D.dset']
-    print fn
-    print surface_extensions
 
     return any(fn.endswith(ext) for ext in surface_extensions)
 

--- a/mvpa2/support/afni/afni_surface_alphasim.py
+++ b/mvpa2/support/afni/afni_surface_alphasim.py
@@ -41,7 +41,7 @@ def _ext(config, for1D=False):
         return ''.join(utils.afni_fileparts(fn)[2:])
 
 def _mask_expr(config):
-    '''returns an expression that can be used as an infix in 
+    '''returns an expression that can be used as an infix in
     running other commands (depending on whether in volume or on surface)'''
     m = config['mask']
     if not m:
@@ -53,7 +53,7 @@ def _mask_expr(config):
             return '-mask %s' % m
 
 def compute_fwhm(config):
-    # helper function - called by critical_clustersize 
+    # helper function - called by critical_clustersize
     # computes FWHM of residuals of input data and stores in config
     output_dir = c['output_dir']
 
@@ -276,7 +276,7 @@ def _remove_files(config, list_of_files):
 def critical_clustersize(config):
     '''computes the critical cluster sizes
     it does so by calling compute_fwhm and null_clustersize
-    
+
     config['max_size'] is a list with he maximum cluster size of
     each iteration'''
 
@@ -308,7 +308,8 @@ def _critical_size_index(config):
 
     idx = math.ceil((1. - pthr) * nsize) # index of critical cluster size
     if idx >= nsize or idx == 0:
-        raise ValueError("Illegal critical index (p=%s): %s" % (pthr, idx))
+        raise ValueError("Illegal critical index (p=%s): %s; "
+                            "consider increasing --niter" % (pthr, idx))
 
     return int(idx)
 
@@ -430,22 +431,22 @@ def get_testing_config():
 def get_options():
     description = '''
     Experimental implementation of alternative AlphaSim for volumes and surfaces.\n
-    
+
     Currently only supports group analysis with t-test against 0.
-    
+
     Input paramaters are an uncorrected t-test threshold (tthr)
     and cluster-size corrected p-value (a.k.a. alpha level) (pthr).
-    
+
     This program takes the following steps:
     (0) Participant's map are t-tested against zero, thresholded by tthr and clustered.
-    (1) residuals are computed by subtracting the group mean from each participants' map 
+    (1) residuals are computed by subtracting the group mean from each participants' map
     (2) the average smoothness of these residual maps is estimated
     (3) null maps are generated from random gaussian noise that is smoothened
-    with the estimated smoothness from step (2), thresholded by tthr, and clustered. 
+    with the estimated smoothness from step (2), thresholded by tthr, and clustered.
     The maximum cluster size is stored for each null map.
     (4) A cluster from (0) survive pthr if a smaller ratio than pthr of the
     null maps generated in (3) have a maximum cluster size.
-    
+
     Copyright 2012 Nikolaas N. Oosterhof <nikolaas.oosterhof@unitn.it>
     '''
 
@@ -455,18 +456,48 @@ def get_options():
 
 
     parser = argparse.ArgumentParser(description=description, epilog=epilog)
-    parser.add_argument("-d", "--data_files", required=True, help="Data input files (that are tested against 0 with a one-sample t-test)", nargs='+')
-    parser.add_argument("-o", "--output_dir", required=True, help="Output directory")
-    parser.add_argument("-s", "--surface_file", required=False, help="Anatomical surface file (.asc)", default=None)
-    parser.add_argument("-t", "--tthr", required=True, help="t-test uncorrected threshold", type=float)
-    parser.add_argument("-p", "--pthr", required=False, help="p-value for corrected threshold", type=float, default=.05)
-    parser.add_argument("-n", "--niter", required=False, help="Number of iterations", type=int, default=1000)
-    parser.add_argument("-i", "--brik_index", required=False, help="Brik index in input files", type=int, default=0)
-    parser.add_argument("-P", "--prefix", required=False, help="Prefix for data output", default='alphasim_')
-    parser.add_argument("-m", "--mask", required=False, help="Mask dataset", default=None)
-    parser.add_argument("-k", "--keep_files", required=False, help="Keep temporary files", default=False, action="store_true")
-    parser.add_argument("-N", "--pad_to_node", required=False, help="pad_to_node (for surfaces)", default=0, type=int)
-    parser.add_argument('-S', "--sigma", required=False, help='sigma for SurfSmooth', default=0., type=float)
+    parser.add_argument("-d", "--data_files", required=True,
+                            help=("Data input files (that are tested against "
+                                "0 with a one-sample t-test)"), nargs='+')
+    parser.add_argument("-o", "--output_dir", required=True,
+                            help="Output directory")
+    parser.add_argument("-s", "--surface_file", required=False,
+                            help=("Anatomical surface file (.asc); required"
+                                    " for surface-based analysis"),
+                            default=None)
+    parser.add_argument("-t", "--tthr", required=True,
+                            help="t-test uncorrected threshold", type=float)
+    parser.add_argument("-p", "--pthr", required=False,
+                            help="p-value for corrected threshold",
+                            type=float, default=.05)
+    parser.add_argument("-n", "--niter", required=False,
+                            help="Number of iterations", type=int,
+                            default=1000)
+    parser.add_argument("-i", "--brik_index", required=False,
+                            help="Brik index in input files",
+                            type=int, default=0)
+    parser.add_argument("-P", "--prefix", required=False,
+                            help="Prefix for data output",
+                            default='alphasim_')
+    parser.add_argument("-m", "--mask", required=False,
+                            help="Mask dataset", default=None)
+    parser.add_argument("-k", "--keep_files", required=False,
+                            help="Keep temporary files", default=False,
+                            action="store_true")
+    parser.add_argument("-N", "--pad_to_node", required=False,
+                            help="pad_to_node (for surfaces)",
+                            default=0, type=int)
+    parser.add_argument('-S', "--sigma", required=False,
+                            help=('sigma (smoothing bandwidth) for SurfSmooth. '
+                                    'If smoothing of surface '
+                                    'data takes a long time, '
+                                    'set this value to a value between 1 and '
+                                    '1.5 and see how many smoothing '
+                                    'iterations are performed. '
+                                    'Ideally, the number of '
+                                    'smoothing iterations should be between '
+                                    '10 and 20'),
+                            default=0., type=float)
 
     args = None
     namespace = parser.parse_args(args)
@@ -482,6 +513,20 @@ def fix_options(config):
         return y
 
     for i in xrange(len(config['data_files'])):
+        full_path=f(config['data_files'][i])
+
+        if _extension_indicates_surface_file(full_path) and \
+                                            not _is_surf(config):
+            raise ValueError("Input file %d (%s) indicates surface-based "
+                                "input but '--surface_file' was not specified."
+                                " To use this function for surface-based "
+                                "analysis, supply an anatomical surface "
+                                "file (preferably the intermediate surface "
+                                "[=the node-wise average of the pial and "
+                                "white surface], or alternatively, a pial "
+                                "or white surface) using the --surface_file "
+                                "option." % (i+1, full_path))
+
         config['data_files'][i] = f(config['data_files'][i])
 
     config['output_dir'] = f(config['output_dir'], check=False)
@@ -496,6 +541,14 @@ def fix_options(config):
     if p <= 0 or p >= 1:
         raise ValueError('Require 0 < pthr < 1')
     _critical_size_index(config) # raises error if p too small
+
+
+def _extension_indicates_surface_file(fn):
+    surface_extensions=['.gii','.niml.dset','.1D','.1D.dset']
+    print fn
+    print surface_extensions
+
+    return any(fn.endswith(ext) for ext in surface_extensions)
 
 
 


### PR DESCRIPTION
This PR addresses a question on the PyMVPA mailing list [1].
For surface-based analysis, if an anatomical surface file is not specified, a more informative error message is provided. 
In addition, this PR fixes some whitespace issues following PEP8.

[1] http://lists.alioth.debian.org/pipermail/pkg-exppsy-pymvpa/2015q2/003092.html