### PR TITLE
MSC: update copyright and developer info to reflect current state

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -14,9 +14,9 @@ documentation is covered by the MIT license.
 
   The MIT License
 
-  Copyright (c) 2006-2014 Michael Hanke
-                2007-2014 Yaroslav Halchenko
-                2012-2014 Nikolaas N. Oosterhof
+  Copyright (c) 2006-2015 Michael Hanke
+                2007-2015 Yaroslav Halchenko
+                2012-2015 Nikolaas N. Oosterhof
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/doc/source/contributors.txt
+++ b/doc/source/contributors.txt
@@ -8,7 +8,7 @@ The PyMVPA developers team currently consists of:
 
 * `Michael Hanke`_, University of Magdeburg, Germany
 * `Yaroslav O. Halchenko`_, Dartmouth College, USA
-* `Nikolaas N. Oosterhof`_, Dartmouth College, USA
+* `Nikolaas N. Oosterhof`_, University of Trento, Italy
 
 We are very grateful to the following people, who have contributed
 valuable advice, code or documentation to PyMVPA:
@@ -51,7 +51,7 @@ valuable advice, code or documentation to PyMVPA:
 .. _James M. Hughes: http://www.cs.dartmouth.edu/~hughes/index.html
 .. _James Kyle: http://www.ccn.ucla.edu/users/jkyle
 .. _Emanuele Olivetti: http://sra.fbk.eu/people/olivetti/
-.. _Nikolaas N. Oosterhof: http://haxbylab.dartmouth.edu/ppl/nno.html 
+.. _Nikolaas N. Oosterhof: http://www5.unitn.it/People/it/Web/Persona/PER0120101
 .. _Russell Poldrack: http://www.poldracklab.org
 .. _Stefan Pollmann: http://apsy.gse.uni-magdeburg.de/pollmann
 .. _Rajeev Raizada: http://www.dartmouth.edu/~raj


### PR DESCRIPTION
Very minor update for copyright year (2014 -> 2015)  and affiliation. 

@hanke, @yarikoptic, are there new contributors we should add? 