### PR TITLE
RF+TST+DOC: Single strip_nibabel() to take care of dtype conversion

### DIFF
--- a/mvpa2/tests/test_niftidataset.py
+++ b/mvpa2/tests/test_niftidataset.py
@@ -18,7 +18,9 @@ if not externals.exists('nibabel'):
 
 from mvpa2.base.dataset import vstack
 from mvpa2 import pymvpa_dataroot
-from mvpa2.datasets.mri import fmri_dataset, _load_anyimg, map2nifti
+from mvpa2.datasets import Dataset
+from mvpa2.datasets.mri import fmri_dataset, _load_anyimg, map2nifti, \
+    strip_nibabel
 from mvpa2.datasets.eventrelated import eventrelated_dataset
 from mvpa2.misc.fsl import FslEV3
 from mvpa2.misc.support import Event, value2idx
@@ -423,3 +425,20 @@ def test_assumptions_on_nibabel_behavior(filename):
         else:
             assert_true(slope in (1.0, None))
             assert_true(inter in (0, None))
+
+
+def test_strip_nibabel():
+    # lots of implicit test already, just make sure it doesn't ruin other
+    # datasets
+    ds = Dataset([range(5)])
+    strip_nibabel(ds)
+    assert_true('imgtype' not in ds.a)
+    # can run multiple times: idempotent
+    ds = fmri_dataset(os.path.join(
+        pymvpa_dataroot, 'openfmri', 'sub001', 'BOLD', 'task001_run001',
+        'bold_25mm.nii.gz'))
+    strip_nibabel(ds)  # this is real
+    strip_nibabel(ds)  # this is not a copy&paste error!
+    assert_true('imgtype' in ds.a)
+    assert_true('imgaffine' in ds.a)
+    assert_equal(type(ds.a.imghdr), dict)

--- a/tools/strip_nibabel
+++ b/tools/strip_nibabel
@@ -37,7 +37,7 @@ This tools support HDF5 files containing a single dataset, as well as
 files with sequences of datasets.
 
 If you have a more complicated conversion task, please inspect the function
-``convert_dataset()`` in this script to aid a custom conversion.
+``strip_nibabel()`` used in this script to aid a custom conversion.
 """
 
 __docformat__ = 'restructuredtext'
@@ -48,26 +48,15 @@ import sys
 sys.path = [sys.argv[1]] + sys.path
 
 from mvpa2.base.hdf5 import h5load, h5save
-from mvpa2.datasets.mri import _hdr2dict
-
-
-def convert_dataset(ds):
-    # only str class name is stored
-    ds.a['imgtype'] = ds.a.imgtype.__name__
-    # new dataset store the affine directly
-    ds.a['imgaffine'] = ds.a.imghdr.get_best_affine()
-    # dict(array) stores header info
-    ds.a['imghdr'] = _hdr2dict(ds.a.imghdr)
-    return ds
-
+from mvpa2.datasets.mri import _hdr2dict, strip_nibabel
 
 oldfname, newfname = sys.argv[2:4]
 
 src = h5load(oldfname)
 
 if isinstance(src, list) or isinstance(src, tuple):
-    out = [convert_dataset(s) for s in src]
+    out = [strip_nibabel(s) for s in src]
 else:
-    out = convert_dataset(src)
+    out = strip_nibabel(src)
 
 h5save(newfname, out, compression=9)


### PR DESCRIPTION
I finally arrived (cognitively) at the location that @nno was already at yesterday. Here is a simple RF that centralizes the bits introduced yesterday.