### PR TITLE
BF+NF+ENH: assert_datasets_equal (stub) + test_generate_testing_fmri_dataset

### DIFF
--- a/mvpa2/misc/support.py
+++ b/mvpa2/misc/support.py
@@ -321,7 +321,7 @@ def version_to_tuple(v):
     of numerics and alpha numbers
     """
     if isinstance(v, basestring):
-        v = v.split('.')
+        v = map(str, v.split('.'))
     elif isinstance(v, tuple) or isinstance(v, list):
         # assure tuple
         pass
@@ -372,6 +372,9 @@ class SmartVersion(Version):
         return self.__class__, (self.vstring,)
 
     def parse(self, vstring):
+        # Unicode gives grief on older releases and anyway arguably comparable
+        if isinstance(vstring, unicode):
+            vstring = str(vstring)
         self.vstring = vstring
         self.version = version_to_tuple(vstring)
 
@@ -385,7 +388,7 @@ class SmartVersion(Version):
             return ""
 
     def __cmp__(self, other):
-        if isinstance(other, (str, tuple, list)):
+        if isinstance(other, (str, unicode, tuple, list)):
             other = SmartVersion(other)
         elif isinstance(other, SmartVersion):
             pass

--- a/mvpa2/testing/regress.py
+++ b/mvpa2/testing/regress.py
@@ -34,8 +34,15 @@ def get_testing_fmri_dataset_filename():
 
     return os.path.join(pymvpa_dataroot, 'testing', 'fmri_dataset', filename)
 
-def generate_testing_fmri_dataset():
+
+def generate_testing_fmri_dataset(filename=None):
     """Helper to generate a dataset for regression testing of mvpa2/nibabel
+
+    Parameters
+    ----------
+    filename : str
+       Filename of a dataset file to store.  If not provided, it is composed
+       using :func:`get_testing_fmri_dataset_filename`
 
     Returns
     -------
@@ -44,7 +51,7 @@ def generate_testing_fmri_dataset():
     """
     import mvpa2
     from mvpa2.base.hdf5 import h5save
-    from mvpa2.misc.data_generators import load_example_fmri_dataset
+    from mvpa2.datasets.sources import load_example_fmri_dataset
     # Load our sample dataset
     ds_full = load_example_fmri_dataset(name='1slice', literal=False)
     # Subselect a small "ROI"
@@ -54,15 +61,17 @@ def generate_testing_fmri_dataset():
     ds.a['versions'] = mvpa2.externals.versions
     # save to a file identified by version of PyMVPA and nibabel and hash of
     # all other versions
-    filename = get_testing_fmri_dataset_filename()
-    h5save(filename, ds, compression=9)
+    out_filename = filename or get_testing_fmri_dataset_filename()
+    h5save(out_filename, ds, compression=9)
     # ATM it produces >700kB .hdf5 which is this large because of
     # the ds.a.mapper with both Flatten and StaticFeatureSelection occupying
     # more than 190kB each, with ds.a.mapper as a whole generating 570kB file
     # Among those .ca seems to occupy notable size, e.g. 130KB for the FlattenMapper
     # even though no heavy storage is really needed for any available value --
     # primarily all is meta-information embedded into hdf5 to describe our things
-    return ds, filename
+    return ds, out_filename
+
+generate_testing_fmri_dataset.__test__ = False
 
 if __name__ == '__main__':
     generate_testing_fmri_dataset()

--- a/mvpa2/testing/tools.py
+++ b/mvpa2/testing/tools.py
@@ -59,8 +59,22 @@ from numpy.testing import (
     assert_array_almost_equal, assert_array_equal, assert_array_less,
     assert_string_equal)
 
+
 def assert_array_lequal(x, y):
     assert_array_less(-y, -x)
+
+
+def assert_dict_keys_equal(x, y):
+    assert_equal(set(x.keys()), set(y.keys()))
+
+
+def assert_datasets_equal(x, y):
+    # wait for https://github.com/PyMVPA/PyMVPA/issues/167
+    assert_equal(type(x), type(y))
+    assert_dict_keys_equal(x.a, y.a)
+    assert_dict_keys_equal(x.sa, y.sa)
+    assert_dict_keys_equal(x.fa, y.fa)
+    assert_array_equal(x.samples, y.samples)
 
 if sys.version_info < (2, 7):
     # compatibility helpers for testing functions introduced in more recent versions

--- a/mvpa2/tests/test_support.py
+++ b/mvpa2/tests/test_support.py
@@ -217,7 +217,7 @@ class SupportFxTests(unittest.TestCase):
         """
         SV = SmartVersion
 
-        for v1, v2 in (
+        for v1_, v2_ in (
             ('0.0.1', '0.0.2'),
             ('0.0.1', '0.1'),
             ('0.0.1', '0.1.0'),
@@ -232,6 +232,9 @@ class SupportFxTests(unittest.TestCase):
             ('0.0.1~p', '0.0.1'),
             ('0.0.1~prior.1.2', '0.0.1'),
             ):
+          for v1, v2 in itertools.product(
+                  (v1_, unicode(v1_)),
+                  (v2_, unicode(v2_))):
             self.assertTrue(SV(v1) < SV(v2),
                             msg="Failed to compare %s to %s" % (v1, v2))
             self.assertTrue(SV(v2) > SV(v1),

--- a/mvpa2/tests/test_testing.py
+++ b/mvpa2/tests/test_testing.py
@@ -92,6 +92,7 @@ def test_with_tempfile(suffix, prefix): #, mkdir):
 def test_generate_testing_fmri_dataset(tempfile):
     skip_if_no_external('nibabel')
     skip_if_no_external('h5py')
+
     from mvpa2.base.hdf5 import h5load
     from mvpa2.testing.regress import generate_testing_fmri_dataset
 

--- a/mvpa2/tests/test_testing.py
+++ b/mvpa2/tests/test_testing.py
@@ -10,6 +10,8 @@
 
 import numpy as np
 
+from os.path import exists
+
 from mvpa2.base.externals import versions
 from mvpa2.testing.tools import *
 from mvpa2.testing.sweep import *
@@ -85,3 +87,16 @@ def test_with_tempfile(suffix, prefix): #, mkdir):
     assert_equal(len(files), 2)
     assert_false(os.path.exists(files[0]))
     assert_false(os.path.exists(files[1]))
+
+@with_tempfile('.hdf5')
+def test_generate_testing_fmri_dataset(tempfile):
+    skip_if_no_external('nibabel')
+    skip_if_no_external('h5py')
+    from mvpa2.base.hdf5 import h5load
+    from mvpa2.testing.regress import generate_testing_fmri_dataset
+
+    ds, filename = generate_testing_fmri_dataset(tempfile)
+    assert_equal(tempfile, filename)
+    assert_true(exists(tempfile))
+    ds_reloaded = h5load(tempfile)
+    assert_datasets_equal(ds, ds_reloaded)


### PR DESCRIPTION
got broken due to recent renames

to fix first Travis failure had to make SmartVersion explicitly convert unicode in versions to str

all for good! ;)