### PR TITLE
WiP: Next generation Hyperalignment API

### DIFF
--- a/mvpa2/tests/test_hyperalignment.py
+++ b/mvpa2/tests/test_hyperalignment.py
@@ -11,6 +11,7 @@
 import unittest
 import numpy as np
 
+from mvpa2.testing.tools import *
 from mvpa2.base import cfg
 from mvpa2.datasets.base import Dataset
 
@@ -297,6 +298,39 @@ class HyperAlignmentTests(unittest.TestCase):
         mkdg_all.sa['chunks'] = np.repeat(range(10), 56)
         bsc_orig = cvterr(mkdg_all)
         print 1 - np.mean(bsc_orig)
+
+
+# once with datasets of different shape
+# once with datasets of with same number of samples
+# once with datasets of with same number of features
+# once with datasets of same shape
+@sweepargs(pair=((Dataset(np.arange(24).reshape(6, 4)),
+                  Dataset(np.arange(24).reshape(8, 3))),
+                 (Dataset(np.arange(24).reshape(6, 4)),
+                  Dataset(np.arange(18).reshape(6, 3))),
+                 (Dataset(np.arange(24).reshape(4, 6)),
+                  Dataset(np.arange(18).reshape(3, 6))),
+                 (Dataset(np.arange(12).reshape(3, 4)),
+                  Dataset(np.arange(12).reshape(3, 4)))))
+def test_ds_of_ds(pair):
+    ds1, ds2 = pair
+    # stuff into a single dataset, where each sample is a whole dataset
+    ds = Dataset([ds1, ds2])
+    assert_equal(ds.shape, (2, 1))
+    assert_equal(ds.samples.dtype, np.object)
+    # nothing stupid happened, the sample arrays are still views of the common
+    # ancestor
+    assert_equal(id(ds1.samples.base), id(ds.samples[0, 0].samples.base))
+    assert_equal(id(ds2.samples.base), id(ds.samples[1, 0].samples.base))
+
+
+def test_mapper():
+    ds_orig = datasets['uni4large']
+    nds = 2
+    dss = [random_affine_transformation(ds_orig, scale_fac=100, shift_fac=10)
+           for i in range(nds)]
+    ds = Dataset(dss)
+    assert_equal(len(ds), nds)
 
 
 def suite():  # pragma: no cover

--- a/mvpa2/tests/test_hyperalignment.py
+++ b/mvpa2/tests/test_hyperalignment.py
@@ -19,7 +19,6 @@ from mvpa2.algorithms.hyperalignment import Hyperalignment
 from mvpa2.mappers.zscore import zscore
 from mvpa2.misc.support import idhash
 from mvpa2.misc.data_generators import random_affine_transformation
-from mvpa2.misc.fx import get_random_rotation
 
 # Somewhat slow but provides all needed ;)
 from mvpa2.testing import sweepargs, reseed_rng
@@ -30,8 +29,8 @@ from mvpa2.generators.partition import NFoldPartitioner
 # if you need some classifiers
 #from mvpa2.testing.clfs import *
 
-class HyperAlignmentTests(unittest.TestCase):
 
+class HyperAlignmentTests(unittest.TestCase):
 
     @sweepargs(zscore_all=(False, True))
     @sweepargs(zscore_common=(False, True))
@@ -49,7 +48,7 @@ class HyperAlignmentTests(unittest.TestCase):
         # lets select for now only meaningful features
         ds_orig = ds4l[:, ds4l.a.nonbogus_features]
         nf = ds_orig.nfeatures
-        n = 4 # # of datasets to generate
+        n = 4  # of datasets to generate
         Rs, dss_rotated, dss_rotated_clean, random_shifts, random_scales \
             = [], [], [], [], []
 
@@ -91,9 +90,11 @@ class HyperAlignmentTests(unittest.TestCase):
 
             idhashes_ = [idhash(ds.samples) for ds in dss]
             idhashes_targets_ = [idhash(ds.targets) for ds in dss]
-            self.assertEqual(idhashes, idhashes_,
+            self.assertEqual(
+                idhashes, idhashes_,
                 msg="Hyperalignment must not change original data.")
-            self.assertEqual(idhashes_targets, idhashes_targets_,
+            self.assertEqual(
+                idhashes_targets, idhashes_targets_,
                 msg="Hyperalignment must not change original data targets.")
 
             self.assertEqual(ref_ds, ha.ca.chosen_ref_ds)
@@ -107,8 +108,7 @@ class HyperAlignmentTests(unittest.TestCase):
             nddss = []
             ndcss = []
             ds_orig_Rref = np.dot(ds_orig.samples, Rs[ref_ds]) \
-                           * random_scales[ref_ds] \
-                           + random_shifts[ref_ds]
+                * random_scales[ref_ds] + random_shifts[ref_ds]
             if zscore_common or zscore_all:
                 zscore(Dataset(ds_orig_Rref), chunks_attr=None)
             for ds_back in dss_clean_back:
@@ -125,32 +125,34 @@ class HyperAlignmentTests(unittest.TestCase):
             do_labile = cfg.getboolean('tests', 'labile', default='yes')
             if not noisy or do_labile:
                 # First compare correlations
-                self.assertTrue(np.all(np.array(ndcss)
-                                       >= (0.9, 0.85)[int(noisy)]),
-                        msg="Should have reconstructed original dataset more or"
+                self.assertTrue(
+                    np.all(np.array(ndcss) >= (0.9, 0.85)[int(noisy)]),
+                    msg="Should have reconstructed original dataset more or"
                         " less. Got correlations %s in %s case."
                         % (ndcss, snoisy))
                 if not (zscore_all or zscore_common):
                     # if we didn't zscore -- all of them should be really close
-                    self.assertTrue(np.all(np.array(nddss)
-                                       <= (1e-10, 1e-1)[int(noisy)]),
+                    self.assertTrue(
+                        np.all(np.array(nddss) <= (1e-10, 1e-1)[int(noisy)]),
                         msg="Should have reconstructed original dataset well "
                         "without zscoring. Got normed differences %s in %s case."
                         % (nddss, snoisy))
                 elif do_labile:
                     # otherwise they all should be somewhat close
-                    self.assertTrue(np.all(np.array(nddss)
-                                           <= (.2, 3)[int(noisy)]),
+                    self.assertTrue(
+                        np.all(np.array(nddss) <= (.2, 3)[int(noisy)]),
                         msg="Should have reconstructed original dataset more or"
                         " less for all. Got normed differences %s in %s case."
                         % (nddss, snoisy))
-                    self.assertTrue(np.all(nddss[ref_ds] <= .09),
+                    self.assertTrue(
+                        np.all(nddss[ref_ds] <= .09),
                         msg="Should have reconstructed original dataset quite "
                         "well even with zscoring. Got normed differences %s "
                         "in %s case." % (nddss, snoisy))
                     # yoh: and leave 5% of difference for a chance and numerical
                     #      fluctuations ;)
-                    self.assertTrue(np.all(np.array(nddss) >= 0.95*nddss[ref_ds]),
+                    self.assertTrue(
+                        np.all(np.array(nddss) >= 0.95 * nddss[ref_ds]),
                         msg="Should have reconstructed orig_ds best of all. "
                         "Got normed differences %s in %s case with ref_ds=%d."
                         % (nddss, snoisy, ref_ds))
@@ -160,8 +162,9 @@ class HyperAlignmentTests(unittest.TestCase):
                             enable_ca=['training_residual_errors',
                                        'residual_errors'])
         mappers = ha(dss_rotated_clean)
-        self.assertTrue(np.all(ha.ca.training_residual_errors.sa.levels ==
-                              ['1', '2:0', '2:1']))
+        self.assertTrue(
+            np.all(
+                ha.ca.training_residual_errors.sa.levels == ['1', '2:0', '2:1']))
         rterrors = ha.ca.training_residual_errors.samples
         # just basic tests:
         self.assertEqual(rterrors[0, ref_ds], 0)
@@ -178,8 +181,8 @@ class HyperAlignmentTests(unittest.TestCase):
         _ = [zscore(sd, chunks_attr=None) for sd in ds_all]
         # Making random data per subject for testing with bias added to first subject
         ds_test = [np.random.rand(1, ds.nfeatures) for i in range(len(ds_all))]
-        ds_test[0] += np.arange(1, ds.nfeatures+1)*100
-        assert(np.corrcoef(ds_test[2], ds_test[1])[0,1] < 0.99) # that would have been rudiculous if it was
+        ds_test[0] += np.arange(1, ds.nfeatures + 1) * 100
+        assert(np.corrcoef(ds_test[2], ds_test[1])[0, 1] < 0.99)  # that would have been rudiculous if it was
 
         # Test with varying alpha so we for sure to not have that issue now
         for alpha in (0, 0.01, 0.5, 0.99, 1.0):
@@ -189,7 +192,6 @@ class HyperAlignmentTests(unittest.TestCase):
             ds_test_a = [mappers[0].reverse(sd) for sd in ds_test_a]
             corr = np.corrcoef(ds_test_a[2], ds_test_a[1])[0, 1]
             assert(corr < 0.99)
-
 
     def _test_on_swaroop_data(self):  # pragma: no cover
         #
@@ -201,14 +203,14 @@ class HyperAlignmentTests(unittest.TestCase):
         subj = ['cb', 'dm', 'hj', 'kd', 'kl', 'mh', 'ph', 'rb', 'se', 'sm']
         ds = []
         for sub in subj:
-            ds.append(fmri_dataset(samples=sub+'_movie.nii.gz',
-                                   mask=sub+'_mask_vt.nii.gz'))
+            ds.append(fmri_dataset(samples=sub + '_movie.nii.gz',
+                                   mask=sub + '_mask_vt.nii.gz'))
 
         '''
         Compute feature ranks in each dataset
         based on correlation with other datasets
         '''
-        feature_scores = [ np.zeros(ds[i].nfeatures) for i in range(len(subj)) ]
+        feature_scores = [np.zeros(ds[i].nfeatures) for i in range(len(subj))]
         '''
         for i in range(len(subj)):
             ds_temp = ds[i].samples - np.mean(ds[i].samples, axis=0)
@@ -223,22 +225,22 @@ class HyperAlignmentTests(unittest.TestCase):
         for i, sd in enumerate(ds):
             ds_temp = sd.copy()
             zscore(ds_temp, chunks_attr=None)
-            for j, sd2 in enumerate(ds[i+1:]):
+            for j, sd2 in enumerate(ds[i + 1:]):
                 ds_temp2 = sd2.copy()
                 zscore(ds_temp2, chunks_attr=None)
                 corr_temp = np.dot(ds_temp.samples.T, ds_temp2.samples)
-                feature_scores[i] = feature_scores[i] + \
-                                    np.max(corr_temp, axis = 1)
-                feature_scores[j+i+1] = feature_scores[j+i+1] + \
-                                        np.max(corr_temp, axis = 0)
+                feature_scores[i] = \
+                    feature_scores[i] + np.max(corr_temp, axis=1)
+                feature_scores[j + i + 1] = \
+                    feature_scores[j + i + 1] + np.max(corr_temp, axis=0)
 
         for i, sd in enumerate(ds):
             sd.fa['bsc_scores'] = feature_scores[i]
 
-        fselector = FixedNElementTailSelector(2000,
-                                              tail='upper', mode='select')
+        fselector = FixedNElementTailSelector(
+            2000, tail='upper', mode='select')
 
-        ds_fs = [ sd[:, fselector(sd.fa.bsc_scores)] for sd in ds]
+        ds_fs = [sd[:, fselector(sd.fa.bsc_scores)] for sd in ds]
 
         hyper = Hyperalignment()
         mapper_results = hyper(ds_fs)
@@ -246,13 +248,13 @@ class HyperAlignmentTests(unittest.TestCase):
         md_cd = ColumnData('labels.txt', header=['label'])
         md_labels = [int(x) for x in md_cd['label']]
         for run in range(8):
-            md_labels[192*run:192*run+3] = [-1]*3
+            md_labels[192 * run:192 * run + 3] = [-1] * 3
 
         mkdg_ds = []
         for sub in subj:
             mkdg_ds.append(fmri_dataset(
-                samples=sub+'_mkdg.nii.gz', targets=md_labels,
-                chunks=np.repeat(range(8), 192), mask=sub+'_mask_vt.nii.gz'))
+                samples=sub + '_mkdg.nii.gz', targets=md_labels,
+                chunks=np.repeat(range(8), 192), mask=sub + '_mask_vt.nii.gz'))
 
         m = mean_group_sample(['targets', 'chunks'])
 
@@ -264,9 +266,9 @@ class HyperAlignmentTests(unittest.TestCase):
         for i, sd in enumerate(mkdg_ds):
             sd.fa['bsc_scores'] = feature_scores[i]
 
-        mkdg_ds_fs = [ sd[:, fselector(sd.fa.bsc_scores)] for sd in mkdg_ds]
-        mkdg_ds_mapped = [ sd.get_mapped(mapper_results[i])
-                           for i, sd in enumerate(mkdg_ds_fs)]
+        mkdg_ds_fs = [sd[:, fselector(sd.fa.bsc_scores)] for sd in mkdg_ds]
+        mkdg_ds_mapped = [sd.get_mapped(mapper_results[i])
+                          for i, sd in enumerate(mkdg_ds_fs)]
 
         # within-subject classification
         within_acc = []
@@ -275,12 +277,12 @@ class HyperAlignmentTests(unittest.TestCase):
                                  enable_ca=['confusion'])
         for sd in mkdg_ds_fs:
             wsc = cvterr(sd)
-            within_acc.append(1-np.mean(wsc))
+            within_acc.append(1 - np.mean(wsc))
 
         within_acc_mapped = []
         for sd in mkdg_ds_mapped:
             wsc = cvterr(sd)
-            within_acc_mapped.append(1-np.mean(wsc))
+            within_acc_mapped.append(1 - np.mean(wsc))
 
         print np.mean(within_acc)
         print np.mean(within_acc_mapped)
@@ -290,13 +292,11 @@ class HyperAlignmentTests(unittest.TestCase):
         mkdg_ds_all.sa['chunks'] = mkdg_ds_all.sa['subject']
 
         bsc = cvterr(mkdg_ds_all)
-        print 1-np.mean(bsc)
+        print 1 - np.mean(bsc)
         mkdg_all = vstack(mkdg_ds_fs)
         mkdg_all.sa['chunks'] = np.repeat(range(10), 56)
         bsc_orig = cvterr(mkdg_all)
-        print 1-np.mean(bsc_orig)
-        pass
-
+        print 1 - np.mean(bsc_orig)
 
 
 def suite():  # pragma: no cover
@@ -306,4 +306,3 @@ def suite():  # pragma: no cover
 if __name__ == '__main__':  # pragma: no cover
     import runner
     runner.run()
-


### PR DESCRIPTION
This is about making the incomprehensible folding strategy shown here

http://www.pymvpa.org/examples/hyperalignment.html

much more simple to write and read.

The basic idea is to start with a dataset that has other datasets as samples whenever dataset features are not congruent  across, e.g. subjects. Such a dataset can have the usual attributes (e.g. chunks) so can be fed into a cross-validation for things like leave-one-subject-out. Any measure running inside the CV can now be prepended with the new, yet-to-be-written Hyperalign() Mapper that can work with these special datasets, computes the common space from the training set, and projects input dataset into the common space when necessary.

In essence this PR will be about implementing this mapper and making various other bits of PyMVPA aware about dataset(datasets) in order to be able to do the right thing (TM).

As this could be implemented in a thousand different ways I am opening this PR right at the start in order to get your comments @yarikoptic @nno and @swaroopgj 