### PR TITLE
ENH: Procrustean mapper now returns transpose as inverse

### DIFF
--- a/mvpa2/mappers/procrustean.py
+++ b/mvpa2/mappers/procrustean.py
@@ -208,3 +208,10 @@ class ProcrusteanMapper(ProjectionMapper):
             d_r = np.linalg.norm(odatas[0] - res_r)/np.linalg.norm(odatas[0])
             debug('MAP_', "%s, residuals are forward: %g,"
                   " reverse: %g" % (repr(self), d_f, d_r))
+
+
+    def _compute_recon(self):
+        """For Procrustean mapper, inverse is transpose.
+        So, let's save on computation time and not introduce new erros(?)
+        """
+        return np.transpose(self._proj)

--- a/mvpa2/mappers/procrustean.py
+++ b/mvpa2/mappers/procrustean.py
@@ -212,6 +212,6 @@ class ProcrusteanMapper(ProjectionMapper):
 
     def _compute_recon(self):
         """For Procrustean mapper, inverse is transpose.
-        So, let's save on computation time and not introduce new erros(?)
+        So, let's skip computing inverse in the super class.
         """
         return np.transpose(self._proj)

--- a/mvpa2/mappers/procrustean.py
+++ b/mvpa2/mappers/procrustean.py
@@ -214,4 +214,9 @@ class ProcrusteanMapper(ProjectionMapper):
         """For Procrustean mapper, inverse is transpose.
         So, let's skip computing inverse in the super class.
         """
-        return np.transpose(self._proj)
+        # XXX Change pinv to superclass compute_recon?
+        if self.params.oblique:
+            #return ProjectionMapper._compute_recon(self)
+            return np.linalg.pinv(self._proj)
+        else:
+            return np.transpose(self._proj/self._scale**2) if self.params.scaling else np.transpose(self._proj)

--- a/mvpa2/tests/test_procrust.py
+++ b/mvpa2/tests/test_procrust.py
@@ -107,8 +107,8 @@ class ProcrusteanMapperTests(unittest.TestCase):
                 d_s_f_r = pm.reverse(d_s_f)
                 # Test if recon proj is true inverse except for high->low projection
                 if nf_s <= nf_t:
-                    self.assertTrue(norm(np.dot(pm._proj, pm._recon) - np.eye(pm._proj.shape[0])) < 1e-10,
-                                msg="Deviation from identity matrix is too large")
+                    assert_almost_equal(np.dot(pm._proj, pm._recon),np.eye(pm._proj.shape[0]),
+                                             err_msg="Deviation from identity matrix is too large")
                 dsfr = d_s_f_r - d_s
                 ndsfr = norm(dsfr)/norm(d_s)
                 if full_test:

--- a/mvpa2/tests/test_procrust.py
+++ b/mvpa2/tests/test_procrust.py
@@ -105,7 +105,10 @@ class ProcrusteanMapperTests(unittest.TestCase):
 
                 # Test if we get back
                 d_s_f_r = pm.reverse(d_s_f)
-
+                # Test if recon proj is true inverse except for high->low projection
+                if nf_s <= nf_t:
+                    self.assertTrue(norm(np.dot(pm._proj, pm._recon) - np.eye(pm._proj.shape[0])) < 1e-10,
+                                msg="Deviation from identity matrix is too large")
                 dsfr = d_s_f_r - d_s
                 ndsfr = norm(dsfr)/norm(d_s)
                 if full_test:


### PR DESCRIPTION
instead of computing inverse (as part of super class)
This should be faster and possibly avert any numerical errors that might creep up during numpy.linalg.inv()