### PR TITLE
ENH: Added passing fa to Projection mappers using Node.pass_attr

### DIFF
--- a/mvpa2/base/node.py
+++ b/mvpa2/base/node.py
@@ -84,6 +84,8 @@ class Node(ClassWithCollections):
           'pvalues', while swapping the first and second axes. Simplified
           instructions can be given by leaving out consecutive tuple elements
           starting from the end.
+          Note: For Projection-derived mappers, this only passes attributes when
+          calling the object but not when `forward` is used to make output dataset.
         postproc : Node instance, optional
           Node to perform post-processing of results. This node is applied
           in `__call__()` to perform a final processing step on the to be

--- a/mvpa2/mappers/projection.py
+++ b/mvpa2/mappers/projection.py
@@ -14,7 +14,7 @@ import numpy as np
 
 from mvpa2.base.dochelpers import enhanced_doc_string
 from mvpa2.mappers.base import Mapper, accepts_dataset_as_samples
-
+from mvpa2.base.state import ConditionalAttribute
 
 if __debug__:
     from mvpa2.base import debug
@@ -43,6 +43,8 @@ class ProjectionMapper(Mapper):
     """
 
     _DEV__doc__ = """Think about renaming `demean`, may be `translation`?"""
+    
+    pass_fa = ConditionalAttribute(enabled=False, doc="Output feature attribute")
 
     def __init__(self, demean=True, **kwargs):
         """Initialize the ProjectionMapper
@@ -69,7 +71,8 @@ class ProjectionMapper(Mapper):
         """Offset (most often just mean) in the input space"""
         self._offset_out = None
         """Offset (most often just mean) in the output space"""
-
+        self.ca.pass_fa = None
+        """Feature attribute to be passed onto output dataset"""
     __doc__ = enhanced_doc_string('ProjectionMapper', locals(), Mapper)
 
 

--- a/mvpa2/mappers/staticprojection.py
+++ b/mvpa2/mappers/staticprojection.py
@@ -53,7 +53,18 @@ class StaticProjectionMapper(ProjectionMapper):
 
 
 class StaticProjectionMapperWithAttr(StaticProjectionMapper):
+    """
+    Extends StaticProjectionMapper with the ability to add
+    feature attributes during forward mapping.
 
+    Parameters
+    ----------
+    add_fa : Dictionary of features attributes to be added
+      when forwarding a dataset.
+    **kwargs:
+      All keyword arguments are passed to the StaticProjectionMapper
+      constructor.
+    """
     @borrowdoc(StaticProjectionMapper)
     def __init__(self, proj, recon=None, add_fa=None, **kwargs):
         StaticProjectionMapper.__init__(self, proj=proj, recon=recon, **kwargs)

--- a/mvpa2/mappers/staticprojection.py
+++ b/mvpa2/mappers/staticprojection.py
@@ -51,39 +51,3 @@ class StaticProjectionMapper(ProjectionMapper):
                   (self._proj.shape, np.linalg.norm(self._proj)))
 
 
-
-class StaticProjectionMapperWithAttr(StaticProjectionMapper):
-    """
-    Extends StaticProjectionMapper with the ability to add
-    feature attributes during forward mapping.
-
-    Parameters
-    ----------
-    add_fa : Dictionary of features attributes to be added
-      when forwarding a dataset.
-    **kwargs:
-      All keyword arguments are passed to the StaticProjectionMapper
-      constructor.
-    """
-    @borrowdoc(StaticProjectionMapper)
-    def __init__(self, proj, recon=None, add_fa=None, **kwargs):
-        StaticProjectionMapper.__init__(self, proj=proj, recon=recon, **kwargs)
-        self._add_fa = add_fa
-
-    def __train(self, dummyds):
-        if __debug__:
-            if self.add_fa is None:
-                 debug("MAP_", "Mixing matrix has no additional feature attributes")
-            else:
-                 debug("MAP_", "Mixing matrix has additional attributes to apply %s" %
-                      (self._add_fa.keys()))
-
-    def _forward_dataset(self, data):
-        res = StaticProjectionMapper._forward_dataset(self, data)
-        if is_datasetlike(res) and self._add_fa is not None:
-            for key in self._add_fa:
-                res.fa[key] = self._add_fa[key]
-        return res
-
-
-

--- a/mvpa2/mappers/staticprojection.py
+++ b/mvpa2/mappers/staticprojection.py
@@ -11,9 +11,7 @@
 __docformat__ = 'restructuredtext'
 
 import numpy as np
-from mvpa2.base.dochelpers import borrowdoc
 from mvpa2.mappers.projection import ProjectionMapper
-from mvpa2.base.types import is_datasetlike
 
 if __debug__:
     from mvpa2.base import debug
@@ -49,5 +47,6 @@ class StaticProjectionMapper(ProjectionMapper):
         if __debug__:
             debug("MAP_", "Mixing matrix has %s shape and norm=%f" %
                   (self._proj.shape, np.linalg.norm(self._proj)))
+
 
 

--- a/mvpa2/mappers/staticprojection.py
+++ b/mvpa2/mappers/staticprojection.py
@@ -13,6 +13,7 @@ __docformat__ = 'restructuredtext'
 import numpy as np
 from mvpa2.base.dochelpers import borrowdoc
 from mvpa2.mappers.projection import ProjectionMapper
+from mvpa2.base.types import is_datasetlike
 
 if __debug__:
     from mvpa2.base import debug
@@ -48,6 +49,30 @@ class StaticProjectionMapper(ProjectionMapper):
         if __debug__:
             debug("MAP_", "Mixing matrix has %s shape and norm=%f" %
                   (self._proj.shape, np.linalg.norm(self._proj)))
+
+
+
+class StaticProjectionMapperWithAttr(StaticProjectionMapper):
+
+    @borrowdoc(StaticProjectionMapper)
+    def __init__(self, proj, recon=None, add_fa=None, **kwargs):
+        StaticProjectionMapper.__init__(self, proj=proj, recon=recon, **kwargs)
+        self._add_fa = add_fa
+
+    def __train(self, dummyds):
+        if __debug__:
+            if self.add_fa is None:
+                 debug("MAP_", "Mixing matrix has no additional feature attributes")
+            else:
+                 debug("MAP_", "Mixing matrix has additional attributes to apply %s" %
+                      (self._add_fa.keys()))
+
+    def _forward_dataset(self, data):
+        res = StaticProjectionMapper._forward_dataset(self, data)
+        if is_datasetlike(res) and self._add_fa is not None:
+            for key in self._add_fa:
+                res.fa[key] = self._add_fa[key]
+        return res
 
 
 

--- a/mvpa2/tests/test_staticprojection.py
+++ b/mvpa2/tests/test_staticprojection.py
@@ -12,6 +12,7 @@ import numpy as np
 from mvpa2.testing import *
 from mvpa2.testing.datasets import *
 from mvpa2.mappers.staticprojection import StaticProjectionMapper
+from mvpa2.mappers.staticprojection import StaticProjectionMapperWithAttr
 
 
 def test_staticprojection_reverse_fa():
@@ -31,3 +32,15 @@ def test_staticprojection_reverse_fa():
     assert_equal(dsfr.nfeatures, 6)
     assert_equal(dsfr.fa.attr_length, 6)   # .fa knows about them again
     dsfr.fa['new'] = np.arange(6)
+
+def test_staticprojectionwithattr_fa():
+    ds = datasets['uni2small']
+    proj = np.eye(ds.nfeatures)
+    spm = StaticProjectionMapperWithAttr(proj=proj[:,:3], recon=proj[:,:3].T,
+                add_fa={'magic':np.arange(3)})
+    ok_(len(ds.fa) > 0)                   # we have some fa
+    dsf = spm.forward(ds)
+    ok_(len(dsf.fa) > 0)                 # magic fa added as intended
+    assert_string_equal(dsf.fa.keys()[0], 'magic')
+    assert_array_equal(dsf.fa.magic, np.arange(3))
+

--- a/mvpa2/tests/test_staticprojection.py
+++ b/mvpa2/tests/test_staticprojection.py
@@ -12,8 +12,6 @@ import numpy as np
 from mvpa2.testing import *
 from mvpa2.testing.datasets import *
 from mvpa2.mappers.staticprojection import StaticProjectionMapper
-from mvpa2.mappers.staticprojection import StaticProjectionMapperWithAttr
-
 
 def test_staticprojection_reverse_fa():
     ds = datasets['uni2small']
@@ -36,12 +34,14 @@ def test_staticprojection_reverse_fa():
 def test_staticprojection_pass_attr():
     ds = datasets['uni2small']
     proj = np.eye(ds.nfeatures)
-    spm = StaticProjectionMapper(proj=proj[:,:3], recon=proj[:,:3].T,
+    spm = StaticProjectionMapper(proj=proj[:,:3], recon=proj[:,:3].T, demean=False,
                 enable_ca=['pass_fa'],pass_attr=[('ca.pass_fa','fa',1,'magic')])
     spm.ca.pass_fa = np.arange(3)
     ok_(len(ds.fa) > 0)
+    dsf_fwd = spm.forward(ds)
     dsf = spm(ds)
     ok_(len(dsf.fa) > 0)
+    assert_array_equal(dsf.samples, dsf_fwd.samples)
     assert_string_equal(dsf.fa.keys()[0], 'magic')
     assert_array_equal(dsf.fa.magic, np.arange(3))
 

--- a/mvpa2/tests/test_staticprojection.py
+++ b/mvpa2/tests/test_staticprojection.py
@@ -33,14 +33,15 @@ def test_staticprojection_reverse_fa():
     assert_equal(dsfr.fa.attr_length, 6)   # .fa knows about them again
     dsfr.fa['new'] = np.arange(6)
 
-def test_staticprojectionwithattr_fa():
+def test_staticprojection_pass_attr():
     ds = datasets['uni2small']
     proj = np.eye(ds.nfeatures)
-    spm = StaticProjectionMapperWithAttr(proj=proj[:,:3], recon=proj[:,:3].T,
-                add_fa={'magic':np.arange(3)})
-    ok_(len(ds.fa) > 0)                   # we have some fa
-    dsf = spm.forward(ds)
-    ok_(len(dsf.fa) > 0)                 # magic fa added as intended
+    spm = StaticProjectionMapper(proj=proj[:,:3], recon=proj[:,:3].T,
+                enable_ca=['pass_fa'],pass_attr=[('ca.pass_fa','fa',1,'magic')])
+    spm.ca.pass_fa = np.arange(3)
+    ok_(len(ds.fa) > 0)
+    dsf = spm(ds)
+    ok_(len(dsf.fa) > 0)
     assert_string_equal(dsf.fa.keys()[0], 'magic')
     assert_array_equal(dsf.fa.magic, np.arange(3))
 

--- a/mvpa2/tests/test_svdmapper.py
+++ b/mvpa2/tests/test_svdmapper.py
@@ -13,9 +13,9 @@ import unittest
 import numpy as np
 
 from mvpa2.mappers.svd import SVDMapper
-from mvpa2.testing import reseed_rng
+from mvpa2.testing import *
 from mvpa2.support.copy import deepcopy
-
+from mvpa2.testing.datasets import datasets
 
 class SVDMapperTests(unittest.TestCase):
 
@@ -98,6 +98,18 @@ class SVDMapperTests(unittest.TestCase):
         data_r = pm.reverse(data_f)
         self.assertEqual(data_r.shape, (98,40))
 
+    def test_svd_pass_attr(self):
+        ds = datasets['uni2small']
+        spm = SVDMapper(enable_ca=['pass_fa'],pass_attr=[('ca.pass_fa','fa',1,'magic')])
+        spm.ca.pass_fa = np.arange(ds.nfeatures)
+        spm.train(ds)
+        ok_(len(ds.fa) > 0)
+        dsf_fwd = spm.forward(ds)
+        dsf = spm(ds)
+        ok_(len(dsf.fa) > 0)
+        assert_array_equal(dsf.samples, dsf_fwd.samples)
+        assert_string_equal(dsf.fa.keys()[0], 'magic')
+        assert_array_equal(dsf.fa.magic, np.arange(ds.nfeatures))
 
 
 def suite():  # pragma: no cover


### PR DESCRIPTION
This mapper will allow adding feature attributes that will be propagated to datasets that are mapped using this mapper. It is useful to keep track of what the new features are after mapping.