### PR TITLE
tests for NIML unicode support

### DIFF
--- a/mvpa2/datasets/niml.py
+++ b/mvpa2/datasets/niml.py
@@ -29,9 +29,8 @@ import os
 from mvpa2.support.nibabel import afni_niml_dset as niml_dset
 
 from mvpa2.base.collections import SampleAttributesCollection, \
-        FeatureAttributesCollection, DatasetAttributesCollection, \
-        ArrayCollectable
-
+    FeatureAttributesCollection, DatasetAttributesCollection, \
+    ArrayCollectable
 
 from mvpa2.base import warning, debug, externals
 from mvpa2.datasets.base import Dataset
@@ -42,6 +41,7 @@ if externals.exists('h5py'):
 
 _PYMVPA_PREFIX = 'PYMVPA'
 _PYMVPA_SEP = '_'
+
 
 def from_niml(dset, fa_labels=[], sa_labels=[], a_labels=[]):
     '''Convert a NIML dataset to a Dataset
@@ -96,11 +96,11 @@ def from_niml(dset, fa_labels=[], sa_labels=[], a_labels=[]):
                           (fa_labels_, fa),
                           (a_labels_, a)]
 
-    infix2collection = {'sa':sa,
-                      'fa':fa,
-                      'a':a}
+    infix2collection = {'sa': sa,
+                        'fa': fa,
+                        'a': a}
 
-    infix2length = {'sa':nsamples, 'fa':nfeatures}
+    infix2length = {'sa': nsamples, 'fa': nfeatures}
 
     for k, v in dset.iteritems():
         if k in ignore_labels:
@@ -127,7 +127,7 @@ def from_niml(dset, fa_labels=[], sa_labels=[], a_labels=[]):
 
                         if expected_length != len(v):
                             raise ValueError("Unexpected length: %d != %d" %
-                                                (expected_length, len(v)))
+                                             (expected_length, len(v)))
 
                         v = ArrayCollectable(v, length=expected_length)
 
@@ -167,6 +167,7 @@ def from_niml(dset, fa_labels=[], sa_labels=[], a_labels=[]):
     ds = Dataset(np.transpose(data), sa=sa, fa=fa, a=a)
 
     return ds
+
 
 def to_niml(ds):
     '''Convert a Dataset to a NIML dataset
@@ -223,8 +224,9 @@ def to_niml(ds):
 
     return dset
 
+
 def hstack(dsets, pad_to_feature_index=None, hstack_method='drop_nonunique',
-                set_empty_value=0.):
+           set_empty_value=0.):
     '''Stacks NIML datasets while considering node indices
 
     Parameters
@@ -286,11 +288,11 @@ def hstack(dsets, pad_to_feature_index=None, hstack_method='drop_nonunique',
             nfeatures_empty = pad_to - dset.nfeatures
             if nfeatures_empty < 0:
                 raise ValueError("Dataset has %d features, cannot pad "
-                                    "to %d" % (dset.nfeatures, pad_to))
+                                 "to %d" % (dset.nfeatures, pad_to))
 
             # make empty array
             empty_arr = np.zeros((dset.nsamples, nfeatures_empty),
-                                    dtype=dset.samples.dtype) + set_empty_value
+                                 dtype=dset.samples.dtype) + set_empty_value
             empty_dset = Dataset(empty_arr, sa=stripped_dset.sa.copy(deep=True))
 
             # combine current dset and empty array
@@ -306,7 +308,7 @@ def hstack(dsets, pad_to_feature_index=None, hstack_method='drop_nonunique',
 
         hstack_index = node_index + first_node_index
         hstack_other_index = other_index + first_node_index
-        first_node_index += pad_to or (max_node_index + 1) # prepare for next iteration
+        first_node_index += pad_to or (max_node_index + 1)  # prepare for next iteration
 
         padded_dsets.append(padded_dset)
         hstack_indices.append(hstack_index)
@@ -380,9 +382,10 @@ def _find_node_indices(dset, node_indices_labels):
             else:
                 if not np.array_equal(dset.fa[label].value, node_indices_int):
                     raise ValueError("Different indices for feature attributes"
-                                     " %s and %s" % (use_key, label))
+                                     " %s and %s" % (use_label, label))
 
     return None if use_label is None else node_indices_int
+
 
 def write(fn, ds, form='binary'):
     '''Write a Dataset to a file in NIML format
@@ -399,6 +402,7 @@ def write(fn, ds, form='binary'):
     niml_ds = to_niml(ds)
     niml_dset.write(fn, niml_ds, form=form)
 
+
 def read(fn):
     '''Read a Dataset from a file in NIML format
 
@@ -411,21 +415,21 @@ def read(fn):
     readers_converters = {('.dset',): (niml_dset.read, from_niml)}
 
     if externals.exists('h5py'):
-        readers_converters[('.h5py','.hdf')]=(h5load,None)
+        readers_converters[('.h5py', '.hdf')] = (h5load, None)
 
-    keys=[exts for exts in readers_converters.iterkeys()
+    keys = [exts for exts in readers_converters.iterkeys()
             if any(fn.endswith(ext) for ext in exts)]
 
-    n_keys=len(keys)
+    n_keys = len(keys)
 
-    if n_keys==1:
+    if n_keys == 1:
         # single extension matches
-        key=keys[0]
+        key = keys[0]
         reader, converter = readers_converters[key]
 
-        r=reader(fn)
+        r = reader(fn)
         if converter is not None:
-            r=converter(r)
+            r = converter(r)
         return r
 
     else:
@@ -465,4 +469,3 @@ def from_any(x):
         return x
 
     raise ValueError("Not supported: %r" % (x,))
-

--- a/mvpa2/support/nibabel/afni_niml.py
+++ b/mvpa2/support/nibabel/afni_niml.py
@@ -30,11 +30,13 @@ import re, numpy as np, random, os, time, sys, base64, copy, math
 from io import BytesIO
 
 from mvpa2.support.nibabel import afni_niml_types as types
-_RE_FLAGS = re.DOTALL # regular expression matching spans across new lines
+
+_RE_FLAGS = re.DOTALL  # regular expression matching spans across new lines
 
 from mvpa2.base import warning
 
 from mvpa2.base import debug
+
 if __debug__:
     if not "NIML" in debug.registered:
         debug.register("NIML", "NeuroImaging Markup Language")
@@ -43,11 +45,12 @@ _TEXT_ROWSEP = "\n"
 _TEXT_COLSEP = " "
 
 # define NIML specific escape characters
-_ESCAPE = {'&lt;':'<',
-         '&gt;':'>',
-         '&quot;':'"',
-         '&amp;':'&',
-         '&apos;':"'"}
+_ESCAPE = {'&lt;': '<',
+           '&gt;': '>',
+           '&quot;': '"',
+           '&amp;': '&',
+           '&apos;': "'"}
+
 
 def support_lists(f):
     '''Decorater to allow a function to support list input (and output)
@@ -58,13 +61,16 @@ def support_lists(f):
 
     XXX should this be a more universal function for PyMVPA
     '''
+
     def apply_f(x):
         if isinstance(x, (list, tuple)):
             # support nested lists/tuples
             return map(apply_f, x)
         else:
             return f(x)
+
     return apply_f
+
 
 @support_lists
 def decode_escape(s):
@@ -73,12 +79,14 @@ def decode_escape(s):
         s = s.replace(k, v)
     return s
 
+
 @support_lists
 def encode_escape(s):
     '''Applies NIML-specific escape characters'''
     for k, v in _ESCAPE.iteritems():
         s = s.replace(v, k)
     return s
+
 
 def _parse_keyvalues(s):
     '''parse K0=V0 K1=V1 ... and return a dict(K0=V0,K1=V1,...)'''
@@ -88,19 +96,20 @@ def _parse_keyvalues(s):
     m = re.findall(e, s, _RE_FLAGS)
     return dict([(k.decode(), v.decode()) for k, v in m])
 
+
 def _mixedtypes_datastring2rawniml(s, niml):
     '''Converts data with mixed types to raw NIML'''
     tps = niml['vec_typ']
     ncols = len(tps)
     nrows = niml['vec_len']
 
-    s = s.decode() # convert bytearray to string
+    s = s.decode()  # convert bytearray to string
 
     lines = s.strip().split(_TEXT_ROWSEP)
     if len(lines) != nrows:
         raise ValueError("Expected %d rows, but found %d" % (nrows, len(lines)))
 
-    elems = map(lambda x : x.strip().split(_TEXT_COLSEP), lines)
+    elems = map(lambda x: x.strip().split(_TEXT_COLSEP), lines)
     fs = map(types.code2python_convertor, tps)
 
     data = []
@@ -114,7 +123,7 @@ def _mixedtypes_datastring2rawniml(s, niml):
             if not niform is None:
                 raise ValueError('Not supported: have ni_form with mixed types')
 
-            d = np.zeros((nrows,), dtype=tp) # allocate one-dimensional array
+            d = np.zeros((nrows,), dtype=tp)  # allocate one-dimensional array
             for r in xrange(nrows):
                 d[r] = f(elems[r][col])
 
@@ -132,12 +141,12 @@ def _datastring2rawniml(s, niml):
     onetype = types.findonetype(tps)
 
     if onetype is None or ([onetype] == types.str2codes('string') and
-                            len(tps) > 1):
+                                   len(tps) > 1):
         return _mixedtypes_datastring2rawniml(s, niml)
 
     if [onetype] == types.str2codes('string'):
         # single string
-        return decode_escape(s.decode()) # do not string2rawniml
+        return decode_escape(s.decode())  # do not string2rawniml
 
     # numeric, either int or float
     ncols = niml['vec_num']
@@ -147,10 +156,10 @@ def _datastring2rawniml(s, niml):
     niform = niml.get('ni_form', None)
 
     if not niform or niform == 'text':
-        data = np.zeros((nrows, ncols), dtype=tp) # allocate space for data
-        convertor = types.code2python_convertor(onetype) # string to type convertor
+        data = np.zeros((nrows, ncols), dtype=tp)  # allocate space for data
+        convertor = types.code2python_convertor(onetype)  # string to type convertor
 
-        vals = s.split(None) # split by whitespace seperator
+        vals = s.split(None)  # split by whitespace seperator
         if len(vals) != ncols * nrows:
             raise ValueError("unexpected number of elements")
 
@@ -163,7 +172,7 @@ def _datastring2rawniml(s, niml):
 
         if 'base64' in niform:
             debug('NIML', 'base64, %d chars: %s',
-                            (len(s), _partial_string(s, 0)))
+                  (len(s), _partial_string(s, 0)))
 
             s = base64.b64decode(s)
         elif not 'binary' in niform:
@@ -172,15 +181,17 @@ def _datastring2rawniml(s, niml):
         data_1d = np.fromstring(s, dtype=tp)
 
         debug('NIML', 'data vector has %d elements, reshape to %d x %d = %d',
-                        (np.size(data_1d), nrows, ncols, nrows * ncols))
+              (np.size(data_1d), nrows, ncols, nrows * ncols))
 
         data = np.reshape(data_1d, (nrows, ncols))
 
     return data
 
+
 def getnewidcode():
     '''Provides a new (random) id code for a NIML dataset'''
     return ''.join(map(chr, [random.randint(65, 65 + 25) for _ in xrange(24)]))
+
 
 def setnewidcode(s):
     '''Sets a new (random) id code in a NIML dataset'''
@@ -195,6 +206,7 @@ def setnewidcode(s):
                 s[key] = getnewidcode()
             else:
                 setnewidcode(v)
+
 
 def find_attribute_node(niml_dict, key, value, just_one=True):
     '''Finds a NIML node that matches a particular key and value
@@ -223,12 +235,12 @@ def find_attribute_node(niml_dict, key, value, just_one=True):
     tp = type(niml_dict)
     if tp is list:
         r = sum([find_attribute_node(d, key, value, False)
-                            for d in niml_dict], [])
+                 for d in niml_dict], [])
 
     elif tp is dict:
         r = [niml_dict] if niml_dict.get(key, None) == value else []
         r.extend(find_attribute_node(niml_dict[k], key, value, False)
-                        for k, v in niml_dict.iteritems() if type(v) in (list, dict))
+                 for k, v in niml_dict.iteritems() if type(v) in (list, dict))
 
     else:
         return []
@@ -238,11 +250,10 @@ def find_attribute_node(niml_dict, key, value, just_one=True):
         while type(r) is list:
             if len(r) != 1:
                 raise ValueError('Found %d elements matching %s=%s, '
-                             ' but expected 1' % (len(r), key, value))
+                                 ' but expected 1' % (len(r), key, value))
             r = r[0]
 
     return r
-
 
 
 def rawniml2string(p, form='text'):
@@ -267,19 +278,19 @@ def rawniml2string(p, form='text'):
     if not form in ['text', 'binary', 'base64']:
         raise ValueError("Illegal form %s" % form)
 
-    q = p.copy() # make a shallow copy
+    q = p.copy()  # make a shallow copy
 
-    has_body=True
+    has_body = True
 
     if 'nodes' in q:
-        s_body = rawniml2string(q.pop('nodes'), form) # recursion
+        s_body = rawniml2string(q.pop('nodes'), form)  # recursion
     elif 'data' in q:
         data = q.pop('data')
-        data = types.nimldataassupporteddtype(data) # ensure the data format is supported by NIML
+        data = types.nimldataassupporteddtype(data)  # ensure the data format is supported by NIML
         s_body = _data2string(data, form)
 
         if form == 'text':
-            q.pop('ni_form', None) # defaults to text, remove if already there
+            q.pop('ni_form', None)  # defaults to text, remove if already there
         else:
             byteorder = types.data2ni_form(data, form)
             if byteorder:
@@ -289,7 +300,7 @@ def rawniml2string(p, form='text'):
         for f in ['vec_typ', 'vec_len', 'vec_num']:
             q.pop(f, None)
     else:
-        has_body=False
+        has_body = False
 
     s_name = q.pop('name', None).encode()
     s_header = _header2string(q)
@@ -301,20 +312,21 @@ def rawniml2string(p, form='text'):
         delim = ['<', '\n', '/>']
         values = [s_name, s_header]
 
-    delim_enc=map(lambda x:x.encode(), delim)
+    delim_enc = map(lambda x: x.encode(), delim)
 
-    n_delim=len(delim_enc)
-    assert(n_delim==len(values)+1)
+    n_delim = len(delim_enc)
+    assert (n_delim == len(values) + 1)
 
     # zip with unequal length
-    elems=[]
+    elems = []
     for i in xrange(n_delim):
         elems.append(delim_enc[i])
-        if i+1<n_delim:
+        if i + 1 < n_delim:
             # one element less than the number of delimeters
             elems.append(values[i])
 
     return b''.join(elems)
+
 
 def _data2string(data, form):
     '''Converts a data element to binary, text or base64 representation'''
@@ -322,17 +334,17 @@ def _data2string(data, form):
         return ('"%s"' % encode_escape(data)).encode()
 
     elif type(data) is np.ndarray:
-        if form == 'text':
+        if form == 'text' or numpy_data_isstring(data):
             f = types.numpy_data2printer(data)
             nrows, ncols = data.shape
             return _TEXT_ROWSEP.join([_TEXT_COLSEP.join([f(data[row, col])
                                                          for col in xrange(ncols)])
-                                                         for row in xrange(nrows)]).encode()
+                                      for row in xrange(nrows)]).encode()
         elif form == 'binary':
             data_reshaped = data.reshape((data.shape[1], data.shape[0]))
             r = data_reshaped.tostring()
             debug('NIML', 'Binary encoding (len %d -> %d): [%s]' %
-                            (data_reshaped.size, len(r), _partial_string(r, 0)))
+                  (data_reshaped.size, len(r), _partial_string(r, 0)))
             return r
         elif form == 'base64':
             data_reshaped = data.reshape((data.shape[1], data.shape[0]))
@@ -359,10 +371,11 @@ def _data2string(data, form):
 
             return _TEXT_ROWSEP.join([_TEXT_COLSEP.join([fs[col](data[col][row])
                                                          for col in xrange(ncols)])
-                                                         for row in xrange(nrows)]).encode()
+                                      for row in xrange(nrows)]).encode()
 
     else:
         raise TypeError("Unknown type %r" % type(data))
+
 
 def _header2string(p, keyfirst=['dset_type', 'self_idcode', 'filename', 'data_type'], keylast=['ni_form']):
     '''Converts a header element to a string'''
@@ -377,8 +390,9 @@ def _header2string(p, keyfirst=['dset_type', 'self_idcode', 'filename', 'data_ty
                 kvs.append((k, p[k]))
                 added.add(k)
 
-    rs = map(lambda x : '   %s="%s"' % x, kvs)
+    rs = map(lambda x: '   %s="%s"' % x, kvs)
     return ("\n".join(rs)).encode()
+
 
 def read(fn, itemifsingletonlist=True, postfunction=None):
     '''Reads a NIML dataset
@@ -401,6 +415,7 @@ def read(fn, itemifsingletonlist=True, postfunction=None):
     '''
 
     import io
+
     with io.FileIO(fn) as f:
         s = f.read()
 
@@ -413,16 +428,17 @@ def read(fn, itemifsingletonlist=True, postfunction=None):
     else:
         return r
 
+
 def _partial_string(s, i, maxlen=100):
     '''Prints a string partially'''
 
     # length of the string to print
     n = len(s) - i
     if n <= 0 or maxlen == 0:
-        return '' # nothing to print
+        return ''  # nothing to print
 
     if maxlen < 0 or maxlen > n:
-        maxlen = n # print the whole string
+        maxlen = n  # print the whole string
     elif maxlen > n:
         maxlen = n
 
@@ -433,6 +449,7 @@ def _partial_string(s, i, maxlen=100):
     infix = ' ... ' if n > maxlen else ''
 
     return '%s%s%s' % (s[i:(i + startsize)], infix, s[-stopsize:])
+
 
 def string2rawniml(s, i=None):
     '''Parses a NIML string to a raw NIML tree-like structure
@@ -473,7 +490,7 @@ def string2rawniml(s, i=None):
 
     headerpat = b'\W*<(?P<name>\w+)\W(?P<header>.*?)>'
 
-    nimls = [] # here all found parts are stored
+    nimls = []  # here all found parts are stored
 
 
     # Keep on reading new parts
@@ -528,7 +545,7 @@ def string2rawniml(s, i=None):
 
             # parse the keys and values in the header
             debug('NIML', 'Parsing header %s, header end position %d',
-                                                (name, i + m.end()))
+                  (name, i + m.end()))
             niml = _parse_keyvalues(header)
 
             debug('NIML', 'Found keys %s.', (", ".join(niml.keys())))
@@ -537,7 +554,7 @@ def string2rawniml(s, i=None):
 
             if niml.get('ni_form', None) == 'ni_group':
                 # it's a group. Parse the group using recursion
-                debug("NIML", "Starting a group %s >>>" , niml['name'])
+                debug("NIML", "Starting a group %s >>>", niml['name'])
                 i, niml['nodes'] = string2rawniml(s, i)
                 debug("NIML", "<<< ending a group %s", niml['name'])
 
@@ -549,7 +566,7 @@ def string2rawniml(s, i=None):
             else:
                 # it's a normal element with data
                 debug('NIML', 'Parsing element %s from position %d, total '
-                                    'length %d', (niml['name'], i, len(s)))
+                              'length %d', (niml['name'], i, len(s)))
 
                 # set a few data elements
                 datatypes = niml['ni_type']
@@ -561,7 +578,7 @@ def string2rawniml(s, i=None):
 
                 # data can be in string form, binary or base64.
                 is_string = niml['ni_type'] == 'String' or \
-                                not 'ni_form' in niml
+                            not 'ni_form' in niml
                 if is_string:
                     # string form is handled separately. It's easy to parse
                     # because it cannot contain any end markers in the data
@@ -570,14 +587,15 @@ def string2rawniml(s, i=None):
 
                     vec_typ = niml['vec_typ']
                     is_mixed_data = len(set(vec_typ)) > 1
-                    is_multiple_string_data = len(vec_typ) > 1 and types._one_str2code('String') == types.findonetype(vec_typ)
+                    is_multiple_string_data = len(vec_typ) > 1 and types._one_str2code('String') == types.findonetype(
+                        vec_typ)
 
                     if is_mixed_data or is_multiple_string_data:
                         debug("NIML", "Data is mixed type (string=%s)" % is_multiple_string_data)
-                        #strpat = ('\s*(?P<data>.*)\s*</%s>' % \
+                        # strpat = ('\s*(?P<data>.*)\s*</%s>' % \
                         #                        (name.decode())).encode()
                         strpat = ('\s*(?P<data>.*?)\s*</%s>' % \
-                                                (name.decode())).encode()
+                                  (name.decode())).encode()
 
                         m = re.match(strpat, s[i:], _RE_FLAGS)
                         is_string_data = is_multiple_string_data
@@ -589,7 +607,7 @@ def string2rawniml(s, i=None):
 
                         # construct the regular pattern for this string
                         strpat = ('\s*%s(?P<data>[^"]*)[^"]*%s\s*</%s>' % \
-                                                        (quote, quote, name.decode())).encode()
+                                  (quote, quote, name.decode())).encode()
 
                         m = re.match(strpat, s[i:], _RE_FLAGS)
 
@@ -597,7 +615,7 @@ def string2rawniml(s, i=None):
                         # something went wrong
                         raise ValueError("Could not parse string data from "
                                          "pos %d: %s" %
-                                                (i, _partial_string(s, i)))
+                                         (i, _partial_string(s, i)))
 
                     # parse successful - get the parsed data
                     data = m.groupdict()['data']
@@ -630,7 +648,7 @@ def string2rawniml(s, i=None):
                         # hardcode binary data - see how many bytes we need
                         nbytes = _binary_data_bytecount(niml)
                         debug('NIML', 'Raw data with %d bytes - total length '
-                                    '%d, starting at %d', (nbytes, len(s), i))
+                                      '%d, starting at %d', (nbytes, len(s), i))
                         datastring = s[i:(i + nbytes)]
 
                     niml['data'] = _datastring2rawniml(datastring, niml)
@@ -644,7 +662,7 @@ def string2rawniml(s, i=None):
                     if s[i:(i + len(endstr))].decode() != endstr:
                         raise ValueError("Not found expected end string %s"
                                          "  (found %s...)" %
-                                            (endstr, _partial_string(s, i)))
+                                         (endstr, _partial_string(s, i)))
                     i += len(endstr)
 
             debug('NIML', "Adding element '%s' with keys %r" % (niml['name'], niml.keys()))
@@ -681,7 +699,7 @@ def _binary_data_bytecount(niml):
     nb = ncols * nrows * bytes_per_elem
 
     debug('NIML', 'Number of bytes for %s: %d x %d with %d bytes / element',
-                                    (niform, ncols, nrows, bytes_per_elem))
+          (niform, ncols, nrows, bytes_per_elem))
 
     return nb
 
@@ -693,6 +711,7 @@ def write(fnout, niml, form='binary', prefunction=None):
     s = rawniml2string(niml, form=form)
 
     import io
+
     with io.FileIO(fnout, 'w') as f:
         n = f.write(s)
     if n != len(s):

--- a/mvpa2/support/nibabel/afni_niml.py
+++ b/mvpa2/support/nibabel/afni_niml.py
@@ -334,7 +334,7 @@ def _data2string(data, form):
         return ('"%s"' % encode_escape(data)).encode()
 
     elif type(data) is np.ndarray:
-        if form == 'text' or numpy_data_isstring(data):
+        if form == 'text' or types.numpy_data_isstring(data):
             f = types.numpy_data2printer(data)
             nrows, ncols = data.shape
             return _TEXT_ROWSEP.join([_TEXT_COLSEP.join([f(data[row, col])

--- a/mvpa2/support/nibabel/afni_niml_types.py
+++ b/mvpa2/support/nibabel/afni_niml_types.py
@@ -26,17 +26,18 @@ np_types = [np.byte, np.int16, np.int32,
 np_bytecounts = [1, 2, 4, 4, 8, 16, None, None, None]
 
 python_types = [int, int, int,
-              float, float, complex,
-              None, None, str]
+                float, float, complex,
+                None, None, str]
 
-type_names = ['byte'  , 'short'  , 'int'     ,
-          'float' , 'double' , 'complex' ,
-          'rgb'   , 'rgba'   , 'String' ]
+type_names = ['byte', 'short', 'int',
+              'float', 'double', 'complex',
+              'rgb', 'rgba', 'String']
 
-type_alias = [ 'uint8'   , 'int16'   , 'int32'     ,
-            'float32' , 'float64' , 'complex64' ,
-            'rgb8'    , 'rgba8'   , 'CString' ]
+type_alias = ['uint8', 'int16', 'int32',
+              'float32', 'float64', 'complex64',
+              'rgb8', 'rgba8', 'CString']
 type_sep = ","
+
 
 def code2python_convertor(i):
     if i in [0, 1, 2]:
@@ -44,8 +45,9 @@ def code2python_convertor(i):
     if i in [3, 4, 5]:
         return float
     if i in [8]:
-        return lambda x:x.strip('"') # remove quotes
+        return lambda x: x.strip('"')  # remove quotes
     return None
+
 
 def numpy_type2bytecount(tp):
     for i, t in enumerate(np_types):
@@ -53,38 +55,44 @@ def numpy_type2bytecount(tp):
             return np_bytecounts[i]
     return None
 
+
 def numpy_type2name(tp):
     code = numpy_type2code(tp)
     return _one_code2str(code)
 
+
 def numpy_data_isint(data):
     return type(data) is np.ndarray and np.issubdtype(data.dtype, int)
+
 
 def numpy_data_isfloat(data):
     return type(data) is np.ndarray and np.issubdtype(data.dtype, float)
 
+
 def numpy_data_isdouble(data):
     return type(data) is np.ndarray and np.issubdtype(data.dtype, np.double)
 
+
 def numpy_data_isstring(data):
-    return type(data) is np.ndarray and np.issubdtype(data.dtype, np.str)
+    return type(data) is np.ndarray and \
+           (np.issubdtype(data.dtype, np.str) or data.dtype.kind in 'US')
+
 
 def numpy_data2printer(data):
     tp = type(data)
     if tp is list:
         return map(numpy_data2printer, data)
     elif tp is str:
-        return lambda x : '"%s"' % x
+        return lambda x: '"%s"' % x
     elif tp == np.ndarray:
         if numpy_data_isint(data):
-            return lambda x : '%d' % x
+            return lambda x: '%d' % x
         elif numpy_data_isdouble(data):
             return str
         elif numpy_data_isfloat(data):
-            return lambda x : '%f' % x
+            return lambda x: '%f' % x
         elif numpy_data_isstring(data):
-            return lambda x : '"%s"' % x
-
+            return lambda x: '"%s"' % x
 
     raise ValueError("Not understood type %r in %r" % (tp, data))
 
@@ -94,6 +102,7 @@ def code2python_type(i):
         return map(code2python_type, i)
     else:
         return python_types[i]
+
 
 def nimldataassupporteddtype(data):
     tp = type(data)
@@ -140,8 +149,10 @@ def code2numpy_type(i):
     else:
         return np_types[i]
 
+
 def num_codes():
     return len(type_names)
+
 
 def _one_str2code(name):
     lname = name.lower()
@@ -151,11 +162,13 @@ def _one_str2code(name):
                 return i
     return None
 
+
 def _one_code2str(code):
     return type_alias[code]
 
+
 def sametype(p, q):
-    ascode = lambda x:_one_str2code(x) if type(x) is str else x
+    ascode = lambda x: _one_str2code(x) if type(x) is str else x
     pc, qc = ascode(p), ascode(q)
 
     if pc is None or qc is None:
@@ -170,6 +183,7 @@ def codes2str(codes):
     names = [_one_code2str(code) for code in codes]
     return type_sep.join(names)
 
+
 def byteorder_from_niform(niform, dtype):
     if not (niform and type(niform) is str):
         return None
@@ -180,7 +194,7 @@ def byteorder_from_niform(niform, dtype):
     ns = len(split)
     if ns == 1:
         prefix = niform
-        byteorder = 'msbfirst' # the default
+        byteorder = 'msbfirst'  # the default
     elif ns == 2:
         prefix, byteorder = split
     else:
@@ -195,6 +209,7 @@ def byteorder_from_niform(niform, dtype):
 
     raise ValueError('Not understood niform')
 
+
 def data2ni_form(data, form):
     if (type(data) is np.ndarray and
             (numpy_data_isint(data) or numpy_data_isfloat(data))):
@@ -203,7 +218,7 @@ def data2ni_form(data, form):
         if not form in ['binary', 'base64']:
             raise ValueError('illegal form %s' % form)
 
-        if byteorder == '=': # native order
+        if byteorder == '=':  # native order
             byteorder = '<' if sys.byteorder == 'little' else '>'
 
         if byteorder in '<>':
@@ -223,17 +238,17 @@ def str2codes(names):
         np = len(p)
 
         if np == 1:
-            fac = 1 # how many 
+            fac = 1  # how many
         elif np == 2:
             fac = int(p[0])
         else:
             raise ValueError("Not understood: %s" % part)
 
-        code = _one_str2code(p[-1]) # last element for type
+        code = _one_str2code(p[-1])  # last element for type
         codes.extend([code] * fac)
 
-
     return codes
+
 
 def findonetype(tps):
     '''tps is a list of vec_typ'''
@@ -245,5 +260,3 @@ def findonetype(tps):
             return tp
 
     return None
-
-


### PR DESCRIPTION
Following issue #335 raised by @swaroopgj, and PR #339 by @yarikoptic which adds unicode support to h5{save,load}, this PR adds a test for Unicode data for NIML datasets.

At also includes the PEP8 recommendations made in #336. (Apologies for mixing in the  PEP8 stuff, PyCharm was a bit aggressive.)