### PR TITLE
set dataset attributes coming from NIML as vectors, not matrices (if possible)

### DIFF
--- a/mvpa2/datasets/niml.py
+++ b/mvpa2/datasets/niml.py
@@ -43,6 +43,17 @@ _PYMVPA_PREFIX = 'PYMVPA'
 _PYMVPA_SEP = '_'
 
 
+
+def _as_vector_if_matrix_with_single_column(x):
+    '''Helper function'''
+    if isinstance(x, np.ndarray) and \
+                    len(x.shape) == 2 and x.shape[1] == 1:
+        return x.ravel()
+    else:
+        return x
+
+
+
 def from_niml(dset, fa_labels=[], sa_labels=[], a_labels=[]):
     '''Convert a NIML dataset to a Dataset
 
@@ -129,10 +140,14 @@ def from_niml(dset, fa_labels=[], sa_labels=[], a_labels=[]):
                             raise ValueError("Unexpected length: %d != %d" %
                                              (expected_length, len(v)))
 
+                        v = _as_vector_if_matrix_with_single_column(v)
+
                         v = ArrayCollectable(v, length=expected_length)
 
                     collection[short_k] = v
                     continue
+
+        v = _as_vector_if_matrix_with_single_column(v)
 
         found_label = False
 
@@ -144,6 +159,7 @@ def from_niml(dset, fa_labels=[], sa_labels=[], a_labels=[]):
 
         if found_label:
             continue
+
 
         # try to be smart and deduce this from dimensions.
         # this only works if nfeatures!=nsamples otherwise it would be
@@ -167,6 +183,7 @@ def from_niml(dset, fa_labels=[], sa_labels=[], a_labels=[]):
     ds = Dataset(np.transpose(data), sa=sa, fa=fa, a=a)
 
     return ds
+
 
 
 def to_niml(ds):
@@ -223,6 +240,7 @@ def to_niml(ds):
             dset[long_key] = v
 
     return dset
+
 
 
 def hstack(dsets, pad_to_feature_index=None, hstack_method='drop_nonunique',
@@ -323,6 +341,7 @@ def hstack(dsets, pad_to_feature_index=None, hstack_method='drop_nonunique',
     return hstack_dset
 
 
+
 def _find_sample_labels(dset, sample_labels):
     '''Helper function to find labels in this dataset.
     Looks for any in sample_labels and returns the first one
@@ -350,6 +369,7 @@ def _find_sample_labels(dset, sample_labels):
             break
 
     return None if use_label is None else sample_label_list
+
 
 
 def _find_node_indices(dset, node_indices_labels):
@@ -387,6 +407,7 @@ def _find_node_indices(dset, node_indices_labels):
     return None if use_label is None else node_indices_int
 
 
+
 def write(fn, ds, form='binary'):
     '''Write a Dataset to a file in NIML format
 
@@ -401,6 +422,7 @@ def write(fn, ds, form='binary'):
     '''
     niml_ds = to_niml(ds)
     niml_dset.write(fn, niml_ds, form=form)
+
 
 
 def read(fn):
@@ -446,6 +468,7 @@ def read(fn):
                 pass
 
         raise ValueError("Unable to read %s with unclear extension" % fn)
+
 
 
 def from_any(x):

--- a/mvpa2/tests/test_surfing_afni.py
+++ b/mvpa2/tests/test_surfing_afni.py
@@ -176,7 +176,6 @@ class SurfTests(unittest.TestCase):
 
 
         # test NIML I/O
-        fn = 'tmp.niml.dset'
         niml.write(fn, ds)
         ds2 = niml.from_any(fn)
         ds2.a.pop('history')

--- a/mvpa2/tests/test_surfing_afni.py
+++ b/mvpa2/tests/test_surfing_afni.py
@@ -183,6 +183,10 @@ class SurfTests(unittest.TestCase):
         ds2.a.pop('filename')
         ds2.sa.pop('labels')
         ds2.sa.pop('stats')
+
+        # NIML does not support int64, only int32;
+        # stop this from making the test fail
+        ds2.samples = np.asarray(ds2.samples, dtype=np.int64)
         assert_datasets_equal(ds, ds2)
 
 


### PR DESCRIPTION
Fixes an issue uncovered by #328 which added more stringent tests for dataset equality, causing test_surfing_afni.py to fail [1]. The unit test now also cleans up a temporary file after use.

[1] https://travis-ci.org/PyMVPA/PyMVPA/builds/71774997