### PR TITLE
ENH: support origin element in CoSMoMVPA neighbors element

### DIFF
--- a/mvpa2/datasets/cosmo.py
+++ b/mvpa2/datasets/cosmo.py
@@ -731,7 +731,7 @@ class CosmoQueryEngine(QueryEngineInterface):
 
 
     @classmethod
-    def from_mat(cls, neighbors, a=None, fa=None):
+    def from_mat(cls, neighbors, a=None, fa=None, origin=None):
         '''
         Create CosmoQueryEngine from mat struct
 
@@ -745,10 +745,15 @@ class CosmoQueryEngine(QueryEngineInterface):
             dataset attributes to be used for the output of a Searchlight
         fa: None or dict or ArrayCollectable
             dataset attributes to be used for the output of a Searchlight
+        origin:
+            Optional contents of .a and .fa of dataset indexed by neighbors;
+            its content is ignored
 
         Notes
         -----
-        Empty elements are ignored
+        Empty elements are ignored.
+        Future implementations may store the origin element, and check that
+        its contents agrees with a dataset when this instances trains on it.
         '''
 
         neighbors_vec = neighbors.ravel()

--- a/mvpa2/tests/test_cosmo.py
+++ b/mvpa2/tests/test_cosmo.py
@@ -116,7 +116,11 @@ def _create_small_mat_nbrhood_dict():
     fa = _tup2obj([('k', arr([[4., 3., 2., 1.]]))])
     a = _tup2obj([('name', arr(arr(['output'], dtype='O')))])
 
-    return dict(neighbors=neighbors, fa=fa, a=a)
+    # XXX in the future we may want to use a real origin with
+    # contents of .a and .fa taken from the dataset
+    origin = ('unused',0)
+
+    return dict(neighbors=neighbors, fa=fa, a=a, origin=origin)
 
 
 


### PR DESCRIPTION
Minor changes to allow for an .origin element. The current implementation simply ignores it presence.