### PR TITLE
added more informative error msg

### DIFF
--- a/mvpa2/generators/permutation.py
+++ b/mvpa2/generators/permutation.py
@@ -231,6 +231,9 @@ class AttributePermutator(Node):
 
     def _permute_chunks(self, limit_idx, in_pattrs, out_pattrs, chunks=None):
         # limit_idx is doing nothing
+        
+        if chunks == None:
+            raise RuntimeError("Missing 'chunk_attr' for strategy='chunk'")
 
         uniques = np.unique(chunks)
 

--- a/mvpa2/tests/test_generators.py
+++ b/mvpa2/tests/test_generators.py
@@ -392,3 +392,7 @@ def test_permute_chunks():
     for chunk_id in np.unique(pds.sa.chunks):
         chunk_ds = pds[pds.sa.chunks == chunk_id]
         assert_true(is_sorted(chunk_ds.sa.targets))
+        
+    permutation = AttributePermutator(attr='targets',
+                                      strategy='chunks')
+    assert_raises(RuntimeError, permutation, ds)                    


### PR DESCRIPTION
without this raise, it would crash on the next line with "TypeError: 'NoneType' object is not iterable" msg