### PR TITLE
raise error instead of warning

### DIFF
--- a/mvpa2/generators/permutation.py
+++ b/mvpa2/generators/permutation.py
@@ -225,7 +225,7 @@ class AttributePermutator(Node):
                     # Escape as early as possible
                     return
 
-        warning("Permutation via strategy='chunk' makes no sense --"
+        raise RuntimeError("Permutation via strategy='chunk' makes no sense --"
                 " all chunks have the same order of targets: %s"
                 % (sample_targets,))
 

--- a/mvpa2/tests/test_generators.py
+++ b/mvpa2/tests/test_generators.py
@@ -380,8 +380,7 @@ def test_permute_chunks():
     permutation = AttributePermutator(attr='targets',
                                       chunk_attr='chunks',
                                       strategy='chunks',
-                                      assure=True
-                                      )
+                                      assure=True)
     # same targets for every chunk                                 
     ds.sa.targets = range(len(ds[ds.sa.chunks==0]))*len(np.unique(ds.sa.chunks))
     assert_raises(RuntimeError, permutation, ds)

--- a/mvpa2/tests/test_generators.py
+++ b/mvpa2/tests/test_generators.py
@@ -376,15 +376,18 @@ def test_permute_chunks():
         return np.array_equal(np.sort(x), x)
 
     ds = give_data()
-    # change targets labels
-    # there is no target labels permuting within chunks,
-    # assure = True would be error
-    ds.sa['targets'] = range(len(ds.sa.targets))
+  
     permutation = AttributePermutator(attr='targets',
                                       chunk_attr='chunks',
                                       strategy='chunks',
-                                      assure=True)
+                                      assure=True
+                                      )
+    # same targets for every chunk                                 
+    ds.sa.targets = range(len(ds[ds.sa.chunks==0]))*len(np.unique(ds.sa.chunks))
+    assert_raises(RuntimeError, permutation, ds)
 
+    # unique targets for every chunk
+    ds.sa['targets'] = range(len(ds.sa.targets))
     pds = permutation(ds)
 
     assert_false(is_sorted(pds.sa.targets))


### PR DESCRIPTION
Since it will not shuffle anything, there is no reason why anybody should use it despite the warning. Hence it should be an error instead