### PR TITLE
SOM bug fix and periodic boundary conditions

### DIFF
--- a/mvpa2/mappers/som.py
+++ b/mvpa2/mappers/som.py
@@ -209,7 +209,7 @@ class SimpleSOMMapper(Mapper):
         curr_lrate = self.lrate * np.exp(-1.0 * iter / self.iter_scale)
 
         # compute Gaussian influence kernel
-        infl = np.exp((-1.0 * np.power(dqd,2) ) / (2 * curr_max_radius**2))
+        infl = np.exp((-1.0 * dqd ) / (2 * curr_max_radius * iter))
         infl *= curr_lrate
 
         # hard-limit kernel to max radius

--- a/mvpa2/mappers/som.py
+++ b/mvpa2/mappers/som.py
@@ -209,7 +209,7 @@ class SimpleSOMMapper(Mapper):
         curr_lrate = self.lrate * np.exp(-1.0 * iter / self.iter_scale)
 
         # compute Gaussian influence kernel
-        infl = np.exp((-1.0 * dqd ) / (2 * curr_max_radius * iter))
+        infl = np.exp((-1.0 * dqd) / (2 * curr_max_radius * iter))
         infl *= curr_lrate
 
         # hard-limit kernel to max radius

--- a/mvpa2/tests/test_som.py
+++ b/mvpa2/tests/test_som.py
@@ -16,6 +16,29 @@ from mvpa2.mappers.som import SimpleSOMMapper
 from mvpa2.datasets.base import dataset_wizard
 
 class SOMMapperTests(unittest.TestCase):
+    def test_periodic_boundaries(self):
+    
+        som = SimpleSOMMapper((10, 5), 200, learning_rate=0.05) 
+        
+        test_dqdshape = np.array([5,2,5,3])
+
+        # som._dqdshape only defined in newer version
+        # this is not explicitly linked to the periodic boundary conditions,
+        # but had trouble coming up with a simple test for them
+        self.assertTrue((som._dqdshape == test_dqdshape).all())
+    
+    def test_kohonen_update(self):
+        # before update error occured when learning_rate*number of samples > 1
+        # here use extreme learning_rate to force bad behaviour  
+        som = SimpleSOMMapper((10, 5), 200, learning_rate=1.0)
+        
+        trainer = np.ones([8,3])
+        
+        som.train(trainer)
+        
+        # use 10 instead of 4 to allow for some randomness in the training
+        # fail values tend to be closer to 10^30
+        self.assertTrue((np.abs(som.K) <= 10).all())
 
     def test_simple_som(self):
         colors = np.array([[0., 0., 0.], [0., 0., 1.], [0., 1., 0.],


### PR DESCRIPTION
There are two main changes:

-The Kohonen layer is updated with each sample, not just on each iteration. This prevents an issue where if the learning rate * the number of sample was > 1, the Kohonen layer was driven to extreme values.

-The Kohonen layer now has periodic boundaries. This is introduced through precomputing the influence array, then rolling it to the appropriate location for each sample.
(-) a new variable, self._dqdshape, is introduced to make computing the influence layer faster, as it now only needs to be calculated once per iteration and its shape does not change.

Both of these changes have a new test in test_som.py

Hopefully this helps! Apologies if I've done anything wrong, I'm quite new to github.