### PR TITLE
ENH+BF: improve GIFTI functional data mapping support

### DIFF
--- a/mvpa2/datasets/gifti.py
+++ b/mvpa2/datasets/gifti.py
@@ -176,8 +176,14 @@ def map2gifti(ds, filename=None, encoding='GIFTI_ENCODING_B64GZ'):
         return None
 
     def _build_array(data, intent, encoding=encoding):
-        return gifti.GiftiDataArray.from_array(data, intent,
-                                               encoding=encoding)
+        arr = gifti.GiftiDataArray.from_array(data, intent,
+                                              encoding=encoding)
+        # Setting the coordsys argument the constructor would set the matrix
+        # to the 4x4 identity matrix, which is not desired. Instead the
+        # coordsys is explicitly set to None afterwards
+        arr.coordsys = None
+
+        return arr
 
     node_indices_labels = ('node_indices', 'center_ids', 'ids', 'roi_ids')
     node_indices = _get_attribute_value(ds, 'fa', node_indices_labels)
@@ -190,7 +196,6 @@ def map2gifti(ds, filename=None, encoding='GIFTI_ENCODING_B64GZ'):
     for i, sample in enumerate(samples):
         intent = 'NIFTI_INTENT_NONE' if intents is None else intents[i]
         darray = _build_array(sample, intent)
-        darray.coordsys = None
         darrays.append(darray)
 
     image = gifti.GiftiImage(darrays=darrays)

--- a/mvpa2/datasets/gifti.py
+++ b/mvpa2/datasets/gifti.py
@@ -35,6 +35,10 @@ from mvpa2.base.collections import FeatureAttributesCollection, \
 from mvpa2.base.dataset import AttrDataset
 from mvpa2.datasets.base import Dataset
 from mvpa2.base import warning
+from mvpa2.support.nibabel.surf import from_any as surf_from_any
+from mvpa2.support.nibabel.surf_gifti import to_gifti_image as \
+    anat_surf_to_gifti_image
+
 import numpy as np
 
 
@@ -130,7 +134,7 @@ def gifti_dataset(samples, targets=None, chunks=None):
 
 
 
-def map2gifti(ds, filename=None, encoding='GIFTI_ENCODING_B64GZ'):
+def map2gifti(ds, filename=None, encoding='GIFTI_ENCODING_B64GZ', surface=None):
     """Maps data(sets) into a GiftiImage, and optionally saves it to disc.
 
     Parameters
@@ -141,6 +145,10 @@ def map2gifti(ds, filename=None, encoding='GIFTI_ENCODING_B64GZ'):
       Filename to which the GiftiImage is stored
     encoding : "ASCII" or "Base64Binary" or "GZipBase64Binary", optional
       Encoding format of data
+    surface : mvpa2.surf.nibabel.surf.Surface or str, optional
+      Optional anatomical Surface object, or filename of anatomical surface
+      file, to be stored together with the data. This should allow
+      FreeSurfer's mris_convert to read files written by this function
 
     Returns
     -------
@@ -199,6 +207,14 @@ def map2gifti(ds, filename=None, encoding='GIFTI_ENCODING_B64GZ'):
         intent = 'NIFTI_INTENT_NONE' if intents is None else intents[i]
         darray = _build_array(sample, intent)
         darrays.append(darray)
+
+    # if there is a surface, add it
+    if surface is not None:
+        surface_object = surf_from_any(surface, )
+        anat_image = anat_surf_to_gifti_image(surface_object, add_indices=False)
+
+        for darray in anat_image.darrays:
+            darrays.append(darray)
 
     image = gifti.GiftiImage(darrays=darrays)
 

--- a/mvpa2/datasets/gifti.py
+++ b/mvpa2/datasets/gifti.py
@@ -136,7 +136,8 @@ def gifti_dataset(samples, targets=None, chunks=None):
 
 
 
-def map2gifti(ds, filename=None, encoding='GIFTI_ENCODING_B64GZ', surface=None):
+def map2gifti(ds, filename=None, encoding='GIFTI_ENCODING_B64GZ',
+              surface=None):
     """Maps data(sets) into a GiftiImage, and optionally saves it to disc.
 
     Parameters
@@ -186,7 +187,8 @@ def map2gifti(ds, filename=None, encoding='GIFTI_ENCODING_B64GZ', surface=None):
         return None
 
     def _build_array(data, intent, encoding=encoding):
-        dtype = np.int32 if intent == 'NIFTI_INTENT_NODE_INDEX' else np.float32
+        is_integer = intent == 'NIFTI_INTENT_NODE_INDEX'
+        dtype = np.int32 if is_integer else np.float32
 
         arr = gifti.GiftiDataArray.from_array(data.astype(dtype), intent,
                                               encoding=encoding)

--- a/mvpa2/datasets/gifti.py
+++ b/mvpa2/datasets/gifti.py
@@ -176,7 +176,9 @@ def map2gifti(ds, filename=None, encoding='GIFTI_ENCODING_B64GZ'):
         return None
 
     def _build_array(data, intent, encoding=encoding):
-        arr = gifti.GiftiDataArray.from_array(data, intent,
+        dtype = np.int32 if intent == 'NIFTI_INTENT_NODE_INDEX' else np.float32
+
+        arr = gifti.GiftiDataArray.from_array(data.astype(dtype), intent,
                                               encoding=encoding)
         # Setting the coordsys argument the constructor would set the matrix
         # to the 4x4 identity matrix, which is not desired. Instead the

--- a/mvpa2/datasets/gifti.py
+++ b/mvpa2/datasets/gifti.py
@@ -18,8 +18,10 @@ or non-identity affine transformations.
 
 This module supports node data, i.e. each node on the surface has N
 values associated with it (with N>=1). Typical examples include
-time series data and statistical maps. Other types of data, including
-label data or anatomical surfaces, are not supported.
+time series data and statistical maps.
+
+Optionally, anatomical information (vertices and faces) can be stored,
+so that FreeSurfer's mris_convert can read data written by map2gifti.
 
 .. _NiBabel: http://nipy.sourceforge.net/nibabel
 """

--- a/mvpa2/datasets/gifti.py
+++ b/mvpa2/datasets/gifti.py
@@ -190,6 +190,7 @@ def map2gifti(ds, filename=None, encoding='GIFTI_ENCODING_B64GZ'):
     for i, sample in enumerate(samples):
         intent = 'NIFTI_INTENT_NONE' if intents is None else intents[i]
         darray = _build_array(sample, intent)
+        darray.coordsys = None
         darrays.append(darray)
 
     image = gifti.GiftiImage(darrays=darrays)

--- a/mvpa2/support/nibabel/surf.py
+++ b/mvpa2/support/nibabel/surf.py
@@ -2235,8 +2235,8 @@ def from_any(s):
         return s
     elif isinstance(s, basestring):
         return read(s)
-    elif type(s) is tuple and len(ts) == 2:
-        return Surface(ts[0], ts[1])
+    elif type(s) is tuple and len(s) == 2:
+        return Surface(s[0], s[1])
     else:
         raise ValueError("Not understood: %r" % s)
 

--- a/mvpa2/tests/test_giftidataset.py
+++ b/mvpa2/tests/test_giftidataset.py
@@ -311,3 +311,7 @@ def test_gifti_dataset_with_anatomical_surface(fn, format_, include_nodes):
     assert_almost_equal(face_arr.data, faces)
     assert_equal(face_arr.data.dtype, np.int32)
     assert_equal(face_arr.datatype, data_type_codes['int32'])
+
+    # getting the functional data should ignore faces and vertices
+    ds_again = gifti_dataset(img)
+    assert_datasets_almost_equal(ds, ds_again)

--- a/mvpa2/tests/test_giftidataset.py
+++ b/mvpa2/tests/test_giftidataset.py
@@ -16,7 +16,7 @@ if not externals.exists('nibabel'):
 
 from nibabel.gifti import giftiio as nb_giftiio
 from nibabel.gifti import gifti as nb_gifti
-from nibabel.nifti1 import intent_codes
+from nibabel.nifti1 import intent_codes, data_type_codes
 
 from mvpa2.datasets.base import Dataset
 from mvpa2.datasets.gifti import gifti_dataset, map2gifti
@@ -24,7 +24,8 @@ from mvpa2.datasets.gifti import gifti_dataset, map2gifti
 import numpy as np
 
 from mvpa2.testing.tools import assert_datasets_almost_equal, \
-    assert_datasets_equal, assert_equal, assert_raises, with_tempfile
+    assert_datasets_equal, assert_equal, assert_almost_equal, \
+    assert_raises, with_tempfile
 from mvpa2.testing import sweepargs
 
 
@@ -191,6 +192,7 @@ def test_gifti_dataset(fn, format_, include_nodes):
                      intent_codes.code['NIFTI_INTENT_NODE_INDEX'])
         assert_equal(node_arr.coordsys, None)
         assert_equal(node_arr.data.dtype, np.int32)
+        assert_equal(node_arr.datatype, data_type_codes['int32'])
 
         first_data_array_pos = 1
         narrays = nsamples + 1
@@ -218,6 +220,7 @@ def test_gifti_dataset(fn, format_, include_nodes):
 
         assert_equal(arr.coordsys, None)
         assert_equal(arr.data.dtype, np.float32)
+        assert_equal(arr.datatype, data_type_codes['float32'])
 
 
 

--- a/mvpa2/tests/test_giftidataset.py
+++ b/mvpa2/tests/test_giftidataset.py
@@ -175,8 +175,10 @@ def test_gifti_dataset(fn, format_, include_nodes):
     assert (isinstance(img2, nb_gifti.GiftiImage))
     nsamples = ds.samples.shape[0]
     if include_nodes:
-        assert_equal(img2.darrays[0].intent,
+        node_arr = img2.darrays[0]
+        assert_equal(node_arr.intent,
                      intent_codes.code['NIFTI_INTENT_NODE_INDEX'])
+        assert_equal(node_arr.coordsys, None)
         first_data_array_pos = 1
         narrays = nsamples + 1
     else:


### PR DESCRIPTION
This PR improves GIFTI support for functional data and fixes a bug:
- The GIFTI standard is not very clear about the presence of a coordinate matrix for data-arrays that are not point-sets, but FreeSurfer's mris_convert doesn't like their presence. This PR sets these coordinate matrices to None so that they are not stored.
- When storing functional data, is is cast to float32. Similarly, node indices are stored as int32
- map2gifti supports a "surface" argument to store anatomical information, so that FreeSurfer's mris_convert can deal with GIFTI files written by map2gifti