### PR TITLE
Fancy print

### DIFF
--- a/mvpa2/datasets/miscfx.py
+++ b/mvpa2/datasets/miscfx.py
@@ -425,7 +425,7 @@ def to_table(ds, sa=[], fa=[], height=100, width=10, n_digits=6):
 
     def create_attr_panel(ds_attr, keys, length):
         panel = []
-        panel.append(keys) # add header
+        panel.append(keys) #  add header
         for i in range(length):
             panel.append([ds_attr[key][i] for key in keys])
         return panel
@@ -461,6 +461,21 @@ def to_table(ds, sa=[], fa=[], height=100, width=10, n_digits=6):
 
 @datasetmethod
 def prt(ds, sa=[], fa=[], height=50, width=12, n_digits=5):
+    """Prints dataset object in table form
+
+    Parameters
+    ----------
+    sa : list or string, optional
+      Names of sample attributes to be displayed. Empty list will display all
+    fa : list or string, optional
+      Names of feature attributes to be displayed, Empty list will display all
+    height : int, optional
+      Number of rows printed
+    width : int, optional
+      Number of columns printed
+    ndigits : int, optional
+      Number of digits displayed in one cell
+    """
     height = min(ds.shape[0], height)
     width = min(ds.shape[1], width)
     print

--- a/mvpa2/datasets/miscfx.py
+++ b/mvpa2/datasets/miscfx.py
@@ -445,7 +445,6 @@ def to_table(ds, sa=[], fa=[], height=100, width=10, n_digits=6):
     else:
         fa = [fa]
 
-
     sa_panel = create_attr_panel(ds.sa, sa, height)
     fa_panel = np.array(create_attr_panel(ds.fa, fa, width)).transpose()
     vals_panel = np.vstack([ds[i].samples[0][0:width] for i in range(height)])
@@ -454,20 +453,17 @@ def to_table(ds, sa=[], fa=[], height=100, width=10, n_digits=6):
     # add empty row and column, to align it with headers
     vals_panel = np.hstack((np.array([" "*n_digits]*height).reshape(-1, 1), 
                             vals_panel))
-    vals_panel = np.vstack(([""]*(width+1), vals_panel))
-    
+    vals_panel = np.vstack(([""]*(width+1), vals_panel))  
 
     return np.vstack((np.hstack((void, fa_panel)),
                               np.hstack((sa_panel, vals_panel))))
 
 @datasetmethod
 def prt(ds, sa=[], fa=[], height=50, width=12, n_digits=5):
-    print
-    print tabulate(to_table(ds, sa, fa, height, width, n_digits))
-    
     height = min(ds.shape[0], height)
     width = min(ds.shape[1], width)
-
+    print
+    print tabulate(to_table(ds, sa, fa, height, width, n_digits))
     print "Ommitted %s rows and %s columns" %(ds.shape[0]-height, ds.shape[1]-width)
 
 

--- a/mvpa2/datasets/miscfx.py
+++ b/mvpa2/datasets/miscfx.py
@@ -18,6 +18,8 @@ import random
 
 import numpy as np
 
+from tabulate import tabulate
+
 from mvpa2.base.dataset import datasetmethod
 from mvpa2.datasets.base import Dataset
 from mvpa2.base.dochelpers import table2string
@@ -414,6 +416,59 @@ def summary_targets(dataset, targets_attr='targets', chunks_attr='chunks',
     if len(uc) < maxc:
         s += cl_stats(1, uc, chunks_attr, targets_attr)
     return s
+
+
+@datasetmethod
+def to_table(ds, sa=[], fa=[], height=100, width=10, n_digits=6):
+    height = min(ds.shape[0], height)
+    width = min(ds.shape[1], width)
+    
+    def create_attr_panel(ds_attr, keys, length):
+        panel = []
+        panel.append(keys) # add header       
+        for i in range(length):
+            panel.append([ds_attr[key][i] for key in keys])      
+        return panel
+
+    # create empty panel if there are no attributes
+    if len(ds.sa.keys()) == 0:
+        ds.sa[None] = [None]*height
+    if len(ds.fa.keys()) == 0:
+        ds.fa[None] = [None]*width
+
+    if sa == []:
+        sa = ds.sa.keys()
+    else:
+        sa = [sa]
+    if fa == []:
+        fa = ds.fa.keys()
+    else:
+        fa = [fa]
+
+
+    sa_panel = create_attr_panel(ds.sa, sa, height)
+    fa_panel = np.array(create_attr_panel(ds.fa, fa, width)).transpose()
+    vals_panel = np.vstack([ds[i].samples[0][0:width] for i in range(height)])
+    void = np.vstack([['  ']*max(len(sa), 1)] * max(len(fa), 1))
+
+    # add empty row and column, to align it with headers
+    vals_panel = np.hstack((np.array([" "*n_digits]*height).reshape(-1, 1), 
+                            vals_panel))
+    vals_panel = np.vstack(([""]*(width+1), vals_panel))
+    
+
+    return np.vstack((np.hstack((void, fa_panel)),
+                              np.hstack((sa_panel, vals_panel))))
+
+@datasetmethod
+def prt(ds, sa=[], fa=[], height=50, width=12, n_digits=5):
+    print
+    print tabulate(to_table(ds, sa, fa, height, width, n_digits))
+    
+    height = min(ds.shape[0], height)
+    width = min(ds.shape[1], width)
+
+    print "Ommitted %s rows and %s columns" %(ds.shape[0]-height, ds.shape[1]-width)
 
 
 class SequenceStats(dict):

--- a/mvpa2/datasets/miscfx.py
+++ b/mvpa2/datasets/miscfx.py
@@ -75,7 +75,7 @@ def remove_nonfinite_features(dataset):
     """
 
     return dataset[:, np.all(np.isfinite(dataset.samples),axis=0)]
-    
+
 
 
 @datasetmethod
@@ -422,12 +422,12 @@ def summary_targets(dataset, targets_attr='targets', chunks_attr='chunks',
 def to_table(ds, sa=[], fa=[], height=100, width=10, n_digits=6):
     height = min(ds.shape[0], height)
     width = min(ds.shape[1], width)
-    
+
     def create_attr_panel(ds_attr, keys, length):
         panel = []
-        panel.append(keys) # add header       
+        panel.append(keys) # add header
         for i in range(length):
-            panel.append([ds_attr[key][i] for key in keys])      
+            panel.append([ds_attr[key][i] for key in keys])
         return panel
 
     # create empty panel if there are no attributes
@@ -438,11 +438,12 @@ def to_table(ds, sa=[], fa=[], height=100, width=10, n_digits=6):
 
     if sa == []:
         sa = ds.sa.keys()
-    else:
+    elif isinstance(sa, basestring):
         sa = [sa]
+
     if fa == []:
         fa = ds.fa.keys()
-    else:
+    elif isinstance(fa, basestring):
         fa = [fa]
 
     sa_panel = create_attr_panel(ds.sa, sa, height)
@@ -451,9 +452,9 @@ def to_table(ds, sa=[], fa=[], height=100, width=10, n_digits=6):
     void = np.vstack([['  ']*max(len(sa), 1)] * max(len(fa), 1))
 
     # add empty row and column, to align it with headers
-    vals_panel = np.hstack((np.array([" "*n_digits]*height).reshape(-1, 1), 
+    vals_panel = np.hstack((np.array([" "*n_digits]*height).reshape(-1, 1),
                             vals_panel))
-    vals_panel = np.vstack(([""]*(width+1), vals_panel))  
+    vals_panel = np.vstack(([""]*(width+1), vals_panel))
 
     return np.vstack((np.hstack((void, fa_panel)),
                               np.hstack((sa_panel, vals_panel))))

--- a/mvpa2/tests/test_datasetfx.py
+++ b/mvpa2/tests/test_datasetfx.py
@@ -141,78 +141,80 @@ class MiscDatasetFxTests(unittest.TestCase):
             sr = str(r)
             # TODO: check the content
 
-def test_prt():
-    def give_data():
-        y_axis = np.hstack([[i]*10 for i in range(15)])/100.
-        x_axis =  np.array(range(10)*15)
-        vals = (x_axis+y_axis).reshape(15,10)
-        ds = dataset_wizard(vals, targets=range(15))
-        ds.fa['features'] = range(10)
-        return ds
 
-    def starts_with_digit(x):
-        if len(x) > 0:
-            if x[0] in "0123456789":
-                return True
-        return False
+    def test_prt():
+        def give_data():
+            y_axis = np.hstack([[i]*10 for i in range(15)])/100.
+            x_axis =  np.array(range(10)*15)
+            vals = (x_axis+y_axis).reshape(15,10)
+            ds = dataset_wizard(vals, targets=range(15))
+            ds.fa['features'] = range(10)
+            return ds
 
-    def correct_alignment(table, func):
-        for row in table:
-                if starts_with_digit(row):
-                    row = row[np.array([True if starts_with_digit(e)
-                              else False for e in row])]
-                    if row[0] == '10':
-                        assert_true(np.all([func(e, '1') or func(e, '10') for e in row]))
-                    else:
-                        assert_true(np.all([func(e, row[0]) for e in row]))
+        def starts_with_digit(x):
+            if len(x) > 0:
+                if x[0] in "0123456789":
+                    return True
+            return False
 
-    ds = give_data()
-    old_ds = ds.copy()
-    table = ds.to_table()
+        def correct_alignment(table, func):
+            for row in table:
+                    if starts_with_digit(row):
+                        row = row[np.array([True if starts_with_digit(e)
+                                  else False for e in row])]
+                        if row[0] == '10':
+                            assert_true(np.all([func(e, '1') or func(e, '10')
+                                                for e in row]))
+                        else:
+                            assert_true(np.all([func(e, row[0]) for e in row]))
 
-    correct_alignment(table, str.endswith)
-    correct_alignment(table.transpose(), str.startswith)
+        ds = give_data()
+        old_ds = ds.copy()
+        table = ds.to_table()
 
-    # Test sa selection
-    ds.sa['sa2'] = range(10, 25)
-    assert_false(np.all(ds.to_table(sa='targets')[:,0] != ds.to_table(
-                        sa='sa2')[:,0]))
-    assert_array_equal(ds.to_table(sa='targets')[:,1:],
-                       ds.to_table(sa='sa2')[:,1:])
+        correct_alignment(table, str.endswith)
+        correct_alignment(table.transpose(), str.startswith)
 
-    # Test alignment again, with more sa keys
-    ds.sa['sa2'] = range(15)
-    table = ds.to_table()
-    correct_alignment(table, str.endswith)
-    correct_alignment(table.transpose(), str.startswith)
+        # Test sa selection
+        ds.sa['sa2'] = range(10, 25)
+        assert_false(np.all(ds.to_table(sa='targets')[:,0] != ds.to_table(
+                            sa='sa2')[:,0]))
+        assert_array_equal(ds.to_table(sa='targets')[:,1:],
+                           ds.to_table(sa='sa2')[:,1:])
 
-    # Test fa selection
-    ds.fa['fa2'] = range(10, 20)
-    assert_false(np.all(ds.to_table(fa='features')[0,:] != ds.to_table(
-                        fa='fa2')[0,:]))
-    assert_array_equal(ds.to_table(fa='features')[1:,:],
-                       ds.to_table(fa='fa2')[1:,:])
+        # Test alignment again, with more sa keys
+        ds.sa['sa2'] = range(15)
+        table = ds.to_table()
+        correct_alignment(table, str.endswith)
+        correct_alignment(table.transpose(), str.startswith)
 
-    # Test alignment with more fa keys
-    ds.fa['fa2'] = range(10)
-    table = ds.to_table(fa='fa2')
-    correct_alignment(table, str.endswith)
-    correct_alignment(table.transpose(), str.startswith)
+        # Test fa selection
+        ds.fa['fa2'] = range(10, 20)
+        assert_false(np.all(ds.to_table(fa='features')[0,:] != ds.to_table(
+                            fa='fa2')[0,:]))
+        assert_array_equal(ds.to_table(fa='features')[1:,:],
+                           ds.to_table(fa='fa2')[1:,:])
 
-    # Test multiple selection
-    ds.sa['sa3'] = range(15)
-    ds.fa['fa3'] = range(10)
-    assert_not_equal(ds.to_table(sa=['sa2', 'sa3'], fa=['fa2','fa3']).shape,
-                     ds.to_table().shape)
-    ds.prt()
-    # more fa + sa keys
-    table = ds.to_table()
-    correct_alignment(table, str.endswith)
-    correct_alignment(table.transpose(), str.startswith)
+        # Test alignment with more fa keys
+        ds.fa['fa2'] = range(10)
+        table = ds.to_table(fa='fa2')
+        correct_alignment(table, str.endswith)
+        correct_alignment(table.transpose(), str.startswith)
 
-    # Check if ds stays intact
-    table = ds.to_table(n_digits=1)
-    assert_array_equal(ds.samples, old_ds.samples)
+        # Test multiple selection
+        ds.sa['sa3'] = range(15)
+        ds.fa['fa3'] = range(10)
+        assert_not_equal(ds.to_table(sa=['sa2', 'sa3'], fa=['fa2','fa3']).shape,
+                         ds.to_table().shape)
+        ds.prt()
+        # more fa + sa keys
+        table = ds.to_table()
+        correct_alignment(table, str.endswith)
+        correct_alignment(table.transpose(), str.startswith)
+
+        # Check if ds stays intact
+        table = ds.to_table(n_digits=1)
+        assert_array_equal(ds.samples, old_ds.samples)
 
 
 def suite():  # pragma: no cover

--- a/mvpa2/tests/test_datasetfx.py
+++ b/mvpa2/tests/test_datasetfx.py
@@ -206,7 +206,7 @@ class MiscDatasetFxTests(unittest.TestCase):
         ds.fa['fa3'] = range(10)
         assert_not_equal(ds.to_table(sa=['sa2', 'sa3'], fa=['fa2','fa3']).shape,
                          ds.to_table().shape)
-        ds.prt()
+
         # more fa + sa keys
         table = ds.to_table()
         correct_alignment(table, str.endswith)

--- a/mvpa2/tests/test_datasetfx.py
+++ b/mvpa2/tests/test_datasetfx.py
@@ -9,8 +9,8 @@
 """Unit tests for PyMVPA miscelaneouse functions operating on datasets"""
 
 import unittest
-from mvpa2.testing.tools import ok_, assert_equal, assert_array_equal, \
-        reseed_rng, assert_true, assert_false
+from mvpa2.testing.tools import ok_, assert_equal, assert_not_equal, \
+         assert_array_equal, reseed_rng, assert_true, assert_false
 
 import numpy as np
 
@@ -141,76 +141,79 @@ class MiscDatasetFxTests(unittest.TestCase):
             sr = str(r)
             # TODO: check the content
 
-
 def test_prt():
     def give_data():
-        y_axis = np.hstack([[i]*10 for i in range(15)])/100. 
+        y_axis = np.hstack([[i]*10 for i in range(15)])/100.
         x_axis =  np.array(range(10)*15)
         vals = (x_axis+y_axis).reshape(15,10)
         ds = dataset_wizard(vals, targets=range(15))
         ds.fa['features'] = range(10)
-        return ds    
-    
-    
+        return ds
+
     def starts_with_digit(x):
         if len(x) > 0:
             if x[0] in "0123456789":
                 return True
         return False
 
-
     def correct_alignment(table, func):
         for row in table:
-                if starts_with_digit(row):               
+                if starts_with_digit(row):
                     row = row[np.array([True if starts_with_digit(e)
                               else False for e in row])]
-                    if row[0] == '10':                     
+                    if row[0] == '10':
                         assert_true(np.all([func(e, '1') or func(e, '10') for e in row]))
-                    else: 
+                    else:
                         assert_true(np.all([func(e, row[0]) for e in row]))
-                        
-                            
+
     ds = give_data()
     old_ds = ds.copy()
     table = ds.to_table()
-   
+
     correct_alignment(table, str.endswith)
     correct_alignment(table.transpose(), str.startswith)
-    
+
     # Test sa selection
-    ds.sa['some_other_sa'] = range(10, 25)
+    ds.sa['sa2'] = range(10, 25)
     assert_false(np.all(ds.to_table(sa='targets')[:,0] != ds.to_table(
-                        sa='some_other_sa')[:,0]))
-    assert_array_equal(ds.to_table(sa='targets')[:,1:], 
-                       ds.to_table(sa='some_other_sa')[:,1:])
-    
-    # Test alignment again, with more sa keys    
-    ds.sa['some_other_sa'] = range(15)
+                        sa='sa2')[:,0]))
+    assert_array_equal(ds.to_table(sa='targets')[:,1:],
+                       ds.to_table(sa='sa2')[:,1:])
+
+    # Test alignment again, with more sa keys
+    ds.sa['sa2'] = range(15)
     table = ds.to_table()
-    correct_alignment(table, str.endswith)    
-    correct_alignment(table.transpose(), str.startswith)  
-    
+    correct_alignment(table, str.endswith)
+    correct_alignment(table.transpose(), str.startswith)
+
     # Test fa selection
-    ds.fa['some_other_fa'] = range(10, 20)
+    ds.fa['fa2'] = range(10, 20)
     assert_false(np.all(ds.to_table(fa='features')[0,:] != ds.to_table(
-                        fa='some_other_fa')[0,:]))
+                        fa='fa2')[0,:]))
     assert_array_equal(ds.to_table(fa='features')[1:,:],
-                       ds.to_table(fa='some_other_fa')[1:,:])
-    
+                       ds.to_table(fa='fa2')[1:,:])
+
     # Test alignment with more fa keys
-    ds.fa['some_other_fa'] = range(10)
-    table = ds.to_table(fa='some_other_fa')
-    correct_alignment(table, str.endswith)    
-    correct_alignment(table.transpose(), str.startswith)      
-    
+    ds.fa['fa2'] = range(10)
+    table = ds.to_table(fa='fa2')
+    correct_alignment(table, str.endswith)
+    correct_alignment(table.transpose(), str.startswith)
+
+    # Test multiple selection
+    ds.sa['sa3'] = range(15)
+    ds.fa['fa3'] = range(10)
+    assert_not_equal(ds.to_table(sa=['sa2', 'sa3'], fa=['fa2','fa3']).shape,
+                     ds.to_table().shape)
+    ds.prt()
     # more fa + sa keys
     table = ds.to_table()
-    correct_alignment(table, str.endswith)    
-    correct_alignment(table.transpose(), str.startswith)  
-    
+    correct_alignment(table, str.endswith)
+    correct_alignment(table.transpose(), str.startswith)
+
     # Check if ds stays intact
-    table = ds.to_table(n_digits=1)  
+    table = ds.to_table(n_digits=1)
     assert_array_equal(ds.samples, old_ds.samples)
+
 
 def suite():  # pragma: no cover
     return unittest.makeSuite(MiscDatasetFxTests)


### PR DESCRIPTION
Nice printing of dataset objects, so that samples and sa are in rows and features/fa are in columns. Just disclosing it here for a feedback, not intended for merge at the moment. For now it is using external library "tabulate" (pipable, MIT licence). 

usage:
ds.prt()
ds.prt(sa='targets')
ds.prt(sa=['targets', 'chunks'])