### PR TITLE
enable pass_attr in simplestats searchlight when returning raw predictions

### DIFF
--- a/mvpa2/testing/tools.py
+++ b/mvpa2/testing/tools.py
@@ -35,6 +35,7 @@ if externals.exists('nose'):
         # Asserting (pep8-ed from unittest)
         assert_true, assert_false, assert_raises,
         assert_equal, assert_equals, assert_not_equal, assert_not_equals,
+        assert_in,
         # Decorators
         timed, with_setup, raises, istest, nottest, make_decorator)
 else:

--- a/mvpa2/tests/test_searchlight.py
+++ b/mvpa2/tests/test_searchlight.py
@@ -762,6 +762,20 @@ class SearchlightTests(unittest.TestCase):
             for f in glob.glob(tfile + '*'):
                 os.unlink(f)
 
+    def test_adhoc_searchlight_pass_attr(test):
+        ds1 = datasets['3dsmall'].copy(deep=True)
+        # GNB searchlight with raw predictions
+        gnb_sl = GNBSearchlight(
+            GNB(),
+            generator=NFoldPartitioner(count=2),
+            qe=IndexQueryEngine(myspace=Sphere(2)),
+            errorfx=None,
+            pass_attr=ds1.sa.keys())
+        res = gnb_sl(ds1)
+        for k in ds1.sa.keys():
+            assert_in(k, res.sa.keys())
+
+
 def suite():  # pragma: no cover
     return unittest.makeSuite(SearchlightTests)
 


### PR DESCRIPTION
If the partitions schemes doesn't output all samples in the same order for testing set, the passed attr either raise size mismatch or are incoherent.
