### PR TITLE
Cv pass attr

### DIFF
--- a/mvpa2/measures/base.py
+++ b/mvpa2/measures/base.py
@@ -463,7 +463,7 @@ class CrossValidation(RepeatedMeasure):
             splitter = Splitter(generator.get_space(), attr_values=(1, 2))
         # transfer measure to wrap the learner
         # splitter used the output space of the generator to know what to split
-        tm = TransferMeasure(learner, splitter, postproc=enode)
+        tm = TransferMeasure(learner, splitter, postproc=enode, pass_attr=kwargs.pop('pass_attr',None))
 
         space = kwargs.pop('space', 'sa.cvfolds')
         # and finally the repeated measure to perform the x-val
@@ -619,6 +619,7 @@ class TransferMeasure(Measure):
             # will broadcast to desired length
             res.set_attr(space, ("%s->%s" % (train_chunks, test_chunks),))
         # cleanup to free memory
+        self._postcall(dstest, res)
         del dstest
 
         # compute measure stats
@@ -642,6 +643,11 @@ class TransferMeasure(Measure):
                 warning("'training_stats' conditional attribute was enabled, "
                         "but the assigned measure '%s' either doesn't support "
                         "it, or it is disabled" % measure)
+        return res
+
+    def _pass_attr(self, ds, res):
+        if ds.nsamples == res.nsamples:
+            super(TransferMeasure, self)._pass_attr(ds, res)
         return res
 
     measure = property(fget=lambda self:self.__measure)

--- a/mvpa2/measures/base.py
+++ b/mvpa2/measures/base.py
@@ -619,7 +619,7 @@ class TransferMeasure(Measure):
             # will broadcast to desired length
             res.set_attr(space, ("%s->%s" % (train_chunks, test_chunks),))
         # cleanup to free memory
-        self._postcall(dstest, res)
+        self._pass_attr(dstest, res)
         del dstest
 
         # compute measure stats

--- a/mvpa2/tests/test_clfcrossval.py
+++ b/mvpa2/tests/test_clfcrossval.py
@@ -91,6 +91,21 @@ class CrossValidationTests(unittest.TestCase):
         # need to fail, because it can't be split into training and testing
         assert_raises(ValueError, cv, data)
 
+    def test_pass_sa_cv_raw(self):
+        # dataset with indices
+        data = get_mv_pattern(10)
+        data.sa['attr2bepassed'] = np.arange(data.nsamples)
+        # partitioner for cv on part of the data with raw
+        cv = CrossValidation(
+            sample_clf_nl,
+            NFoldPartitioner(count=2),
+            errorfx=None,
+            pass_attr=['attr2bepassed'])
+        res = cv(data)
+        
+        
+        
+
 
 def suite():  # pragma: no cover
     return unittest.makeSuite(CrossValidationTests)


### PR DESCRIPTION
when cross-validating with partitions that doesn't use all dataset as testing or not in the same order than dataset samples, the passed attrs raise error for size mismatch or are either incoherent.
