### PR TITLE
Expose some functionality of group_clusterthr so could be used independently of the GroupClusterThreshold

### DIFF
--- a/mvpa2/algorithms/group_clusterthr.py
+++ b/mvpa2/algorithms/group_clusterthr.py
@@ -462,6 +462,12 @@ def get_thresholding_map(data, p=0.001):
 def _get_map_cluster_sizes(map_):
     labels, num = measurements.label(map_)
     area = measurements.sum(map_, labels, index=np.arange(1, num + 1))
+    # TODO: So here if a given map didn't have any super-thresholded features,
+    # we get 0 into our histogram.  BUT for the other maps, where at least 1 voxel
+    # passed the threshold we might get multiple clusters recorded within our
+    # distribution.  Which doesn't quite cut it for being called a FW cluster level.
+    # MAY BE it should count only the maximal cluster size (a single number)
+    # per given permutation (not all of them)
     if not len(area):
         return [0]
     else:
@@ -469,7 +475,7 @@ def _get_map_cluster_sizes(map_):
 
 
 def get_cluster_sizes(ds, cluster_counter=None):
-    """Computer cluster sizes from all samples in a boolean dataset.
+    """Compute cluster sizes from all samples in a boolean dataset.
 
     Individually for each sample, in the input dataset, clusters of non-zero
     values will be determined after reverse-applying any transformation of the
@@ -480,7 +486,7 @@ def get_cluster_sizes(ds, cluster_counter=None):
     ds : dataset or array
       A dataset with boolean samples.
     cluster_counter : list or None
-      If not None, the given list is extended with the cluster sizes computed
+      If not None, given list is extended with the cluster sizes computed
       from the present input dataset. Otherwise, a new list is generated.
 
     Returns

--- a/mvpa2/algorithms/group_clusterthr.py
+++ b/mvpa2/algorithms/group_clusterthr.py
@@ -552,6 +552,27 @@ def get_cluster_pvals(sizes, null_sizes):
     return pvals
 
 
+def repeat_cluster_vals(cluster_counts, vals=None):
+    """Repeat vals for each count of a cluster size as given in cluster_counts
+
+    Parameters
+    ----------
+    cluster_counts: dict or Counter
+      Contains counts per each cluster size
+    vals : dict or Counter, optional
+
+    Returns
+    -------
+    ndarray
+      Values are ordered according to ascending order of cluster sizes
+    """
+    sizes = sorted(cluster_counts.keys())
+    if vals is None:
+        return np.repeat(sizes, [cluster_counts[s] for s in sizes])
+    else:
+        return np.repeat([vals[s] for s in sizes], [cluster_counts[s] for s in sizes])
+
+
 def _transform_to_pvals(sizes, null_sizes):
     # null_sizes will be modified in-place
     for size in sizes:

--- a/mvpa2/algorithms/group_clusterthr.py
+++ b/mvpa2/algorithms/group_clusterthr.py
@@ -10,8 +10,8 @@
 
 __docformat__ = 'restructuredtext'
 
-__all__ = ['GroupClusterThreshold',  'get_thresholding_map',
-           'get_cluster_sizes']
+__all__ = ['GroupClusterThreshold', 'get_thresholding_map',
+           'get_cluster_sizes', 'get_cluster_pvals']
 
 if __debug__:
     from mvpa2.base import debug
@@ -509,6 +509,47 @@ def get_cluster_sizes(ds, cluster_counter=None):
         m_clusters = _get_map_cluster_sizes(osamp)
         cluster_counter.update(m_clusters)
     return cluster_counter
+
+
+def get_cluster_pvals(sizes, null_sizes):
+    """Get p-value per each cluster size given cluster sizes for null-distribution
+
+    Parameters
+    ----------
+    sizes, null_sizes : Counter
+      Counters of cluster sizes (as returned by get_cluster_sizes) for target
+      dataset and null distribution
+    """
+    # TODO: dedicated unit-test for this function
+    """
+    Development note:
+     Functionality here somewhat dupliactes functionality in _transform_to_pvals
+     which does not operate on raw "Counters" and requires different input format.
+     Altogether with such data preparation _transform_to_pvals was slower than
+     this more naive implementation.
+    """
+    all_sizes = null_sizes + sizes
+    total_count = float(np.sum(all_sizes.values()))
+    # now we need to normalize them counting all to the "right", i.e larger than
+    # current one
+    right_tail = 0
+    all_sizes_sf = {}
+    for cluster_size in sorted(all_sizes)[::-1]:
+        right_tail += all_sizes[cluster_size]
+        all_sizes_sf[cluster_size] = right_tail/total_count
+
+    # now figure out p values for our cluster sizes in real acc (not the P0 distribution),
+    # since some of them might be missing
+    all_sizes_sorted = sorted(all_sizes)
+    pvals = {}
+    for cluster_size in sizes:
+        if cluster_size in all_sizes:
+            pvals[cluster_size] = all_sizes_sf[cluster_size]
+        else:
+            # find the largest smaller than current size
+            clusters = all_sizes_sorted[all_sizes_sorted < cluster_size]
+            pvals[cluster_size] = all_sizes_sf[clusters[-1]]
+    return pvals
 
 
 def _transform_to_pvals(sizes, null_sizes):

--- a/mvpa2/tests/test_group_clusterthr.py
+++ b/mvpa2/tests/test_group_clusterthr.py
@@ -158,7 +158,7 @@ def test_group_clusterthreshold_simple(n_proc):
                     fa=dict(fid=range(perm_samples.shape[1])))
     # the algorithm instance
     # scale number of bootstraps to match desired probability
-    # plus a safety margin to mimimize bad luck in sampling
+    # plus a safety margin to minimize bad luck in sampling
     clthr = gct.GroupClusterThreshold(n_bootstrap=int(3. / feature_thresh_prob),
                                       feature_thresh_prob=feature_thresh_prob,
                                       fwe_rate=0.01, n_blocks=3, n_proc=n_proc)

--- a/mvpa2/tests/test_group_clusterthr.py
+++ b/mvpa2/tests/test_group_clusterthr.py
@@ -271,3 +271,13 @@ def test_group_clusterthreshold_simple(n_proc):
                        res.a.clusterstats['size'])
 
     # TODO continue with somewhat more real dataset
+
+def test_repeat_cluster_vals():
+    assert_array_equal(gct.repeat_cluster_vals({1: 2, 3: 1}), [1, 1, 3])
+    assert_array_equal(gct.repeat_cluster_vals({1: 2, 3: 2, 2: 1}),
+                       [1, 1, 2, 3, 3])
+
+    assert_array_equal(gct.repeat_cluster_vals({1: 2, 3: 1}, {1: 0.2, 3: 0.5}),
+                       [0.2, 0.2, 0.5])
+    assert_array_equal(gct.repeat_cluster_vals({1: 2, 3: 2, 2: 1}, {1: 'a', 2: 'b', 3: 'c'}),
+                       ['a', 'a', 'b', 'c', 'c'])

--- a/mvpa2/tests/test_usecases.py
+++ b/mvpa2/tests/test_usecases.py
@@ -529,7 +529,8 @@ def test_simple_cluster_level_thresholding():
     assert(np.all(acc_p > 0))
 
     # Now we need to do our fancy cluster level madness
-    from mvpa2.algorithms.group_clusterthr import get_cluster_sizes, _transform_to_pvals
+    from mvpa2.algorithms.group_clusterthr import \
+        get_cluster_sizes, _transform_to_pvals, get_cluster_pvals
     rand_cluster_sizes = get_cluster_sizes(rand_acc_p <= pthr_feature)
     acc_cluster_sizes = get_cluster_sizes(acc_p <= pthr_feature)
 
@@ -569,31 +570,8 @@ def test_simple_cluster_level_thresholding():
     #print test_count_sizes, test_pvals
 
 
-    all_cluster_sizes = rand_cluster_sizes + acc_cluster_sizes
-    minimum_cluster_size = None
-    all_clusters_count = np.sum(all_cluster_sizes.values())
-    # now we need to normalize them counting all to the "right", i.e larger than
-    # current one
-    right_tail = 0
-    all_cluster_sizes_sf = {}
-    for cluster_size in sorted(all_cluster_sizes)[::-1]:
-        right_tail += all_cluster_sizes[cluster_size]
-        all_cluster_sizes_sf[cluster_size] = float(right_tail)/all_clusters_count
+    acc_cluster_ps = get_cluster_pvals(acc_cluster_sizes, rand_cluster_sizes)
 
-    # now figure out p values for our cluster sizes in real acc (not the P0 distribution),
-    # since some of them might be missing
-    all_cluster_sizes_sorted = sorted(all_cluster_sizes)
-    acc_cluster_ps = {}
-    for cluster_size in acc_cluster_sizes:
-        if cluster_size in all_cluster_sizes:
-            acc_cluster_ps[cluster_size] = all_cluster_sizes_sf[cluster_size]
-        else:
-            # find the largest smaller than current size
-            clusters = all_cluster_sizes_sorted[all_cluster_sizes_sorted < cluster_size]
-            acc_cluster_ps[cluster_size] = all_cluster_sizes_sf[clusters[-1]]
-
-
-    #print acc_cluster_ps
     for test_pval, test_count_size in zip(test_pvals, test_count_sizes):
         assert_almost_equal(acc_cluster_ps[test_count_size], test_pval)
 

--- a/mvpa2/tests/test_usecases.py
+++ b/mvpa2/tests/test_usecases.py
@@ -11,6 +11,7 @@
 import unittest
 import numpy as np
 
+from mvpa2.testing import skip_if_no_external
 from mvpa2.testing.tools import ok_, assert_array_equal, assert_true, \
         assert_false, assert_equal, assert_not_equal, reseed_rng, assert_raises, \
         assert_array_almost_equal, SkipTest, assert_datasets_equal, assert_almost_equal
@@ -528,6 +529,7 @@ def test_simple_cluster_level_thresholding():
     assert(np.all(acc_p <= 1))
     assert(np.all(acc_p > 0))
 
+    skip_if_no_external('scipy')
     # Now we need to do our fancy cluster level madness
     from mvpa2.algorithms.group_clusterthr import \
         get_cluster_sizes, _transform_to_pvals, get_cluster_pvals, \

--- a/mvpa2/tests/test_usecases.py
+++ b/mvpa2/tests/test_usecases.py
@@ -531,7 +531,7 @@ def test_simple_cluster_level_thresholding():
     # Now we need to do our fancy cluster level madness
     from mvpa2.algorithms.group_clusterthr import \
         get_cluster_sizes, _transform_to_pvals, get_cluster_pvals, \
-        get_thresholding_map
+        get_thresholding_map, repeat_cluster_vals
 
     rand_acc_p_thr = rand_acc_p < pthr_feature
     acc_p_thr = acc_p < pthr_feature
@@ -561,14 +561,7 @@ def test_simple_cluster_level_thresholding():
     for s in rand_cluster_sizes:
         scl[0, s] = rand_cluster_sizes[s]
 
-    n_clusters = np.sum(acc_cluster_sizes.values())
-    test_count_sizes = np.zeros(n_clusters, dtype=int)
-    i = 0
-    for csize, cnumber in acc_cluster_sizes.items():
-        for k in range(cnumber):
-            test_count_sizes[i] = csize
-            i += 1
-
+    test_count_sizes = repeat_cluster_vals(acc_cluster_sizes)
     test_pvals = _transform_to_pvals(test_count_sizes, scl.astype('float'))
     # needs conversion to array for comparisons
     test_pvals = np.asanyarray(test_pvals)

--- a/mvpa2/tests/test_usecases.py
+++ b/mvpa2/tests/test_usecases.py
@@ -499,7 +499,7 @@ def test_searchlight_errors_per_trial():
 
 @reseed_rng()
 def test_simple_cluster_level_thresholding():
-    nf = 10
+    nf = 13
     nperms = 100
     pthr_feature = 0.5  # just for testing
     pthr_cluster = 0.5
@@ -530,9 +530,24 @@ def test_simple_cluster_level_thresholding():
 
     # Now we need to do our fancy cluster level madness
     from mvpa2.algorithms.group_clusterthr import \
-        get_cluster_sizes, _transform_to_pvals, get_cluster_pvals
-    rand_cluster_sizes = get_cluster_sizes(rand_acc_p <= pthr_feature)
-    acc_cluster_sizes = get_cluster_sizes(acc_p <= pthr_feature)
+        get_cluster_sizes, _transform_to_pvals, get_cluster_pvals, \
+        get_thresholding_map
+
+    rand_acc_p_thr = rand_acc_p < pthr_feature
+    acc_p_thr = acc_p < pthr_feature
+
+    rand_cluster_sizes = get_cluster_sizes(rand_acc_p_thr)
+    acc_cluster_sizes = get_cluster_sizes(acc_p_thr)
+
+    # This is how we can compute it within present implementation.
+    # It will be a bit different (since it doesn't account for target value if
+    # I got it right), and would work only for accuracies
+    thr_map = get_thresholding_map(rand_acc, pthr_feature)
+    rand_cluster_sizes_ = get_cluster_sizes(rand_acc > thr_map)
+    acc_cluster_sizes_ = get_cluster_sizes(acc > thr_map)
+
+    assert_equal(rand_cluster_sizes, rand_cluster_sizes_)
+    assert_equal(acc_cluster_sizes, acc_cluster_sizes_)
 
     #print rand_cluster_sizes
     #print acc_cluster_sizes


### PR DESCRIPTION
We wanted to use parts of the implementation for similar cluster level thresholding but without bootstraps and other thrills.  While going through the logic, spotted one point to discuss (how cluster sizes get accumulated, around the point when [0] is returned) and provided few helper functions to work with those Counter's stats on cluster sizes collected, so they could be used easily to estimate p values for non-bootstrapped results.