### PR TITLE
WiP TST(BK): two use-case tests showing problems with adjusted StaticFeatureSelection

### DIFF
--- a/mvpa2/tests/test_mapper.py
+++ b/mvpa2/tests/test_mapper.py
@@ -499,8 +499,12 @@ def test_static_reverse_doesnt_work_after_feature_selection_tuneup_2():
     # would have gone all the way to 3d
     assert_equal(ds_orig_rev0.ndim, 3)
 
-    ds = ds_orig[:, [0, 2]]
-    ds_rev0 = ds.a.mapper.reverse1(ds.samples[0])
-    # blow test fails since chain mapper thrown exception upon _oshape mismatch
-    # but chain mapper silently proceeded forward doing nothing
-    assert_equal(ds_rev0.ndim, 3)
+    bool_mask = np.ones((ds_orig.nfeatures,), dtype=bool)
+    bool_mask[0] = False
+
+    for idx in (bool_mask, [0, 2]):
+        ds = ds_orig[:, idx]
+        ds_rev0 = ds.a.mapper.reverse1(ds.samples[0])
+        # blow test fails since chain mapper thrown exception upon _oshape mismatch
+        # but chain mapper silently proceeded forward doing nothing
+        yield assert_equal, ds_rev0.ndim, 3

--- a/mvpa2/tests/test_mapper.py
+++ b/mvpa2/tests/test_mapper.py
@@ -470,3 +470,37 @@ def test_identity_mapper(s):
     assert_true(idm.forward1(s) is s)
     assert_true(idm.reverse(s) is s)
     assert_true(idm.reverse1(s) is s)
+
+
+def test_static_reverse_doesnt_work_after_feature_selection_tuneup_1():
+    ds_orig = datasets['uni2small'].copy()  # doesn't matter which
+
+    ds = ds_orig.get_mapped(StaticFeatureSelection(np.arange(4)))
+    ds0_rev = ds.a.mapper.reverse1(ds.samples[0])  # should work
+    assert_equal(ds0_rev.shape, (1, ds_orig.nfeatures))
+
+    # direct feature selection
+    ds_ = ds[:, [0, 2]]
+    # should work but doesn't due to
+    # RuntimeError: Cannot reverse-map data since the original data shape is unknown. Either set `dshape` in the constructor, or call train().
+    ds0_rev_ = ds_.a.mapper.reverse1(ds_.samples[0])
+
+def test_static_reverse_doesnt_work_after_feature_selection_tuneup_2():
+    from mvpa2.testing.tools import skip_if_no_external
+    from mvpa2.datasets.mri import fmri_dataset
+    from mvpa2 import pymvpa_dataroot
+    from os.path import join as pathjoin
+    skip_if_no_external('nibabel')
+
+    ds_orig = fmri_dataset(samples=pathjoin(pymvpa_dataroot, 'bold.nii.gz'),
+                           mask=pathjoin(pymvpa_dataroot, 'mask.nii.gz'),
+                           sprefix='voxel')
+    ds_orig_rev0 = ds_orig.a.mapper.reverse1(ds_orig.samples[0])
+    # would have gone all the way to 3d
+    assert_equal(ds_orig_rev0.ndim, 3)
+
+    ds = ds_orig[:, [0, 2]]
+    ds_rev0 = ds.a.mapper.reverse1(ds.samples[0])
+    # blow test fails since chain mapper thrown exception upon _oshape mismatch
+    # but chain mapper silently proceeded forward doing nothing
+    assert_equal(ds_rev0.ndim, 3)


### PR DESCRIPTION
Two tests to demonstrate a problem with "adjusted" StaticFeatureSelection
- in first case it raises exception demanding training (IMHO shouldn't)
- in the 2nd case, with a ChainMapper it pretty much skips any reverse mapping