### PR TITLE
BF: Remove a shadowed externals check to avoid confusion

### DIFF
--- a/mvpa2/base/externals.py
+++ b/mvpa2/base/externals.py
@@ -573,7 +573,6 @@ _KNOWN = {'libsvm': 'import mvpa2.clfs.libsvmc._svm as __; x=__.seq_to_svm_node'
           'reportlab': "__check('reportlab', 'Version')",
           'nose': "import nose as __",
           'pprocess': "__check('pprocess')",
-          'joblib': "__check('joblib')",
           'h5py': "__check_h5py()",
           'hdf5': "__check_h5py()",
           'nipy': "__check('nipy')",


### PR DESCRIPTION
Could be better to do it the other way round though...