### PR TITLE
ENH: make partitioner (aka generator) optional for CrossValidation and ad-hoc searchlights

### DIFF
--- a/mvpa2/generators/partition.py
+++ b/mvpa2/generators/partition.py
@@ -130,7 +130,7 @@ class Partitioner(Node):
 
 
     def get_partitions_attr(self, ds, specs):
-        """Create a partition attribute array for a particular partion spec.
+        """Create a partition attribute array for a particular partition spec.
 
         Parameters
         ----------

--- a/mvpa2/measures/adhocsearchlightbase.py
+++ b/mvpa2/measures/adhocsearchlightbase.py
@@ -136,6 +136,7 @@ class SimpleStatBaseSearchlight(BaseSearchlight):
     def __init__(self, generator, queryengine, errorfx=mean_mismatch_error,
                  indexsum=None,
                  reuse_neighbors=False,
+                 splitter=None,
                  **kwargs):
         """Initialize the base class for "naive" searchlight classifiers
 
@@ -156,6 +157,9 @@ class SimpleStatBaseSearchlight(BaseSearchlight):
           Compute neighbors information only once, thus allowing for
           efficient reuse on subsequent calls where dataset's feature
           attributes remain the same (e.g. during permutation testing)
+        splitter : Splitter, optional
+          Which will be used to split partitioned datasets.  If None specified
+          then standard one operating on partitions will be used
         """
 
         # init base class first
@@ -163,6 +167,7 @@ class SimpleStatBaseSearchlight(BaseSearchlight):
 
         self._errorfx = errorfx
         self._generator = generator
+        self._splitter = splitter
 
         # TODO: move into _call since resetting over default None
         #       obscures __repr__
@@ -194,6 +199,7 @@ class SimpleStatBaseSearchlight(BaseSearchlight):
         return super(SimpleStatBaseSearchlight, self).__repr__(
             prefixes=prefixes
             + _repr_attrs(self, ['generator'])
+            + _repr_attrs(self, ['splitter'])
             + _repr_attrs(self, ['errorfx'], default=mean_mismatch_error)
             + _repr_attrs(self, ['indexsum'])
             + _repr_attrs(self, ['reuse_neighbors'], default=False)
@@ -359,8 +365,15 @@ class SimpleStatBaseSearchlight(BaseSearchlight):
         # indicies
         # XXX we could make it even more lightweight I guess...
         dataset_indicies = Dataset(np.arange(nsamples), sa=dataset.sa)
-        splitter = Splitter(attr=generator.get_space(), attr_values=[1, 2])
-        partitions = list(generator.generate(dataset_indicies))
+
+        splitter = Splitter(attr=generator.get_space(), attr_values=[1, 2]) \
+            if self._splitter is None \
+            else self._splitter
+
+        partitions = list(generator.generate(dataset_indicies)) \
+            if generator \
+            else [dataset_indicies]
+
         if __debug__:
             for p in partitions:
                 if not (np.all(p.sa[targets_sa_name].value == labels)):
@@ -565,6 +578,7 @@ class SimpleStatBaseSearchlight(BaseSearchlight):
         return out
 
     generator = property(fget=lambda self: self._generator)
+    splitter = property(fget=lambda self: self._splitter)
     errorfx = property(fget=lambda self: self._errorfx)
     indexsum = property(fget=lambda self: self._indexsum)
     reuse_neighbors = property(fget=lambda self: self.__reuse_neighbors)

--- a/mvpa2/measures/adhocsearchlightbase.py
+++ b/mvpa2/measures/adhocsearchlightbase.py
@@ -359,7 +359,7 @@ class SimpleStatBaseSearchlight(BaseSearchlight):
         # indicies
         # XXX we could make it even more lightweight I guess...
         dataset_indicies = Dataset(np.arange(nsamples), sa=dataset.sa)
-        splitter = Splitter(attr=generator.get_space())
+        splitter = Splitter(attr=generator.get_space(), attr_values=[1, 2])
         partitions = list(generator.generate(dataset_indicies))
         if __debug__:
             for p in partitions:
@@ -371,7 +371,8 @@ class SimpleStatBaseSearchlight(BaseSearchlight):
         nsplits = len(partitions)
         # ATM we need to keep the splits instead since they are used
         # in two places in the code: step 2 and 5
-        splits = list(tuple(splitter.generate(ds_)) for ds_ in partitions)
+        # We care only about training and testing partitions (i.e. first two)
+        splits = list(tuple(splitter.generate(ds_))[:2] for ds_ in partitions)
         del partitions                    # not used any longer
 
         # 2. Figure out the new 'chunks x labels' blocks of combinations

--- a/mvpa2/tests/test_searchlight.py
+++ b/mvpa2/tests/test_searchlight.py
@@ -36,6 +36,7 @@ from mvpa2.clfs.knn import kNN
 from mvpa2.misc.neighborhood import IndexQueryEngine, Sphere, HollowSphere, CachedQueryEngine
 from mvpa2.misc.errorfx import corr_error, mean_match_accuracy
 from mvpa2.generators.partition import NFoldPartitioner, OddEvenPartitioner, CustomPartitioner
+from mvpa2.generators.splitters import Splitter
 from mvpa2.generators.permutation import AttributePermutator
 from mvpa2.measures.base import CrossValidation
 
@@ -770,10 +771,10 @@ class SearchlightTests(unittest.TestCase):
         res = gnb_sl(ds1)
         assert_false(cached_qe.ids is None)
 
-    def test_gnbsearchlight_3partitions(self):
-        ds = self.dataset
+    def test_gnbsearchlight_3partitions_and_splitter(self):
+        ds = self.dataset[:, :20]
         # custom partitioner which provides 3 partitions
-        part = CustomPartitioner([([0], [1], [2])])
+        part = CustomPartitioner([([2], [3], [1])])
         gnb_sl = sphere_gnbsearchlight(GNB(), part)
         res_gnb_sl = gnb_sl(ds)
 
@@ -782,6 +783,16 @@ class SearchlightTests(unittest.TestCase):
         res_sl = sl(ds)
 
         assert_datasets_equal(res_gnb_sl, res_sl)
+
+        # and theoretically for this simple single cross-validation we could
+        # just use Splitter
+        splitter = Splitter('chunks', [2, 3])
+        # we have to put explicit None since can't become a kwarg in 1 day any
+        # longer here
+        gnb_sl_ = sphere_gnbsearchlight(GNB(), None, splitter=splitter)
+        res_gnb_sl_ = gnb_sl_(ds)
+        assert_datasets_equal(res_gnb_sl, res_gnb_sl_)
+
 
 def suite():  # pragma: no cover
     return unittest.makeSuite(SearchlightTests)

--- a/mvpa2/tests/test_searchlight.py
+++ b/mvpa2/tests/test_searchlight.py
@@ -35,7 +35,7 @@ from mvpa2.clfs.knn import kNN
 
 from mvpa2.misc.neighborhood import IndexQueryEngine, Sphere, HollowSphere, CachedQueryEngine
 from mvpa2.misc.errorfx import corr_error, mean_match_accuracy
-from mvpa2.generators.partition import NFoldPartitioner, OddEvenPartitioner
+from mvpa2.generators.partition import NFoldPartitioner, OddEvenPartitioner, CustomPartitioner
 from mvpa2.generators.permutation import AttributePermutator
 from mvpa2.measures.base import CrossValidation
 
@@ -769,6 +769,19 @@ class SearchlightTests(unittest.TestCase):
         gnb_sl = GNBSearchlight(GNB(), NFoldPartitioner(), qe=cached_qe)
         res = gnb_sl(ds1)
         assert_false(cached_qe.ids is None)
+
+    def test_gnbsearchlight_3partitions(self):
+        ds = self.dataset
+        # custom partitioner which provides 3 partitions
+        part = CustomPartitioner([([0], [1], [2])])
+        gnb_sl = sphere_gnbsearchlight(GNB(), part)
+        res_gnb_sl = gnb_sl(ds)
+
+        # compare results to full blown searchlight
+        sl = sphere_searchlight(CrossValidation(GNB(), part))
+        res_sl = sl(ds)
+
+        assert_datasets_equal(res_gnb_sl, res_sl)
 
 def suite():  # pragma: no cover
     return unittest.makeSuite(SearchlightTests)


### PR DESCRIPTION
generator=None  primarily to facilitate cross- classifications, so people could just specify
a Splitter on the values of the necessary attribute and be done

Also includes a bugfix for ad-hoc searchlights (such as gnbsearchlight) which disallowed to use custom partitioners which return more than 2 partitions.  While at it also made them work with a custom Splitter.