### PR TITLE
BF+ENH: set TR from scan_key for openfmri datasets' with TR=1 in nifti files

### DIFF
--- a/mvpa2/base/externals.py
+++ b/mvpa2/base/externals.py
@@ -582,6 +582,7 @@ _KNOWN = {'libsvm': 'import mvpa2.clfs.libsvmc._svm as __; x=__.seq_to_svm_node'
           'nipy.neurospin': "__check_nipy_neurospin()",
           'statsmodels': 'import statsmodels.api as __',
           'mock': "__check('mock')",
+          'datalad': "__check('datalad')",
           }
 
 


### PR DESCRIPTION
also added datalad external, if crawled openfmri ds 105 is present - smoke testing above
fix on it

also no dedicated unittest etc I would prefer to merge this one asap so ppl could start using OpenFMRIDataset construct with actual openfmri datasets.
