### PR TITLE
NF: support to export NIFTI to CoSMo format

### DIFF
--- a/mvpa2/datasets/cosmo.py
+++ b/mvpa2/datasets/cosmo.py
@@ -188,7 +188,6 @@ def _from_singleton(x, ndim=2):
                          (s, x, x.shape,))
     return x[(0,) * ndim]
 
-
 # dictionary indicating whether elements in .fa, .sa and .a must be
 # transposed for CoSMoMVPA data representation. As in CoSMoMVPA a dataset
 # with .samples PxQ the elements in .fa must be ?xQ, (only) .fa requires
@@ -327,7 +326,6 @@ def _attributes_dict2cosmo(ds):
             dtypes = []
             values = []
 
-
             for k in attr_collection:
                 value = attr_collection[k].value
 
@@ -383,8 +381,8 @@ def _mat_replace_functions_by_string(x):
     can write
     '''
 
-    unsupported_classes=(matlab.mio5_params.MatlabFunction,
-                         FlattenMapper)
+    unsupported_classes = (matlab.mio5_params.MatlabFunction,
+                           FlattenMapper)
 
     if isinstance(x, unsupported_classes):
         return np.asarray('%s' % x)
@@ -499,7 +497,8 @@ def _check_cosmo_dataset(cosmo):
     if abs(decimals_nonzero) > warn_for_extreme_values_decimals:
         msg = ('Samples have extreme values, maximum absolute value is %s; '
                'This may affect some analyses. Considering scaling the samples, '
-               'e.g. by a factor of 10**%d ' % (max_nonzero, -decimals_nonzero))
+               'e.g. by a factor of 10**%d ' % (
+               max_nonzero, -decimals_nonzero))
         warning(msg)
 
 
@@ -670,7 +669,6 @@ class CosmoQueryEngine(QueryEngineInterface):
 
     '''
 
-
     def __init__(self, mapping, a=None, fa=None):
         '''
         Parameters
@@ -716,7 +714,6 @@ class CosmoQueryEngine(QueryEngineInterface):
         attributes['samples'] = np.zeros((0, nfeatures), dtype=np.int_)
         self._dataset_template = Dataset(**attributes)[:, ids]
 
-
     @staticmethod
     def _check_mapping(mapping):
         '''
@@ -729,13 +726,13 @@ class CosmoQueryEngine(QueryEngineInterface):
             if not np.isscalar(k):
                 raise ValueError('Key %s not a scalar' % k)
             if not isinstance(k, int):
-                raise ValueError('Keys %s must be int, found %s' % (k, type(k)))
+                raise ValueError(
+                    'Keys %s must be int, found %s' % (k, type(k)))
             if not isinstance(v, np.ndarray):
                 raise TypeError('Value %s for key %s must be numpy array' %
                                 (v, k))
             if not np.issubdtype(np.int_, v.dtype):
                 raise ValueError('Value %s for key %s must be int' % (v, k))
-
 
     @classmethod
     def from_mat(cls, neighbors, a=None, fa=None, origin=None):
@@ -785,7 +782,6 @@ class CosmoQueryEngine(QueryEngineInterface):
 
         return cls(mapping, a=a, fa=fa)
 
-
     def __repr__(self):
         '''
         Return representation of this instance
@@ -796,7 +792,6 @@ class CosmoQueryEngine(QueryEngineInterface):
                                                 self._mapping,
                                                 template.a,
                                                 template.fa)
-
 
     def __str__(self):
         '''
@@ -812,7 +807,6 @@ class CosmoQueryEngine(QueryEngineInterface):
                  ', '.join(template.fa.keys()),
                  ', '.join(template.a.keys())))
 
-
     def __reduce__(self):
         '''
         Return state of the instance that can be pickled
@@ -820,13 +814,11 @@ class CosmoQueryEngine(QueryEngineInterface):
         template = self._dataset_template
         return (self.__class__, (self._mapping, template.a, template.fa))
 
-
     def __len__(self):
         '''
         Return number of ids (keys)
         '''
         return len(self.ids)
-
 
     def train(self, dataset):
         '''
@@ -834,17 +826,14 @@ class CosmoQueryEngine(QueryEngineInterface):
         '''
         pass
 
-
     def untrain(self):
         '''
         This method does nothing
         '''
         pass
 
-
     def query(self, **kwargs):
         raise NotImplementedError
-
 
     def query_byid(self, id):
         '''
@@ -857,7 +846,6 @@ class CosmoQueryEngine(QueryEngineInterface):
 
         return self._mapping[id]
 
-
     @property
     def ids(self):
         '''
@@ -869,7 +857,6 @@ class CosmoQueryEngine(QueryEngineInterface):
 
         return self._ids
 
-
     @property
     def a(self):
         '''
@@ -879,7 +866,6 @@ class CosmoQueryEngine(QueryEngineInterface):
             Dataset attributes for the output dataset from using this instance
         '''
         return self._dataset_template.a
-
 
     @property
     def fa(self):
@@ -891,7 +877,6 @@ class CosmoQueryEngine(QueryEngineInterface):
             It has as many elements as self.ids
         '''
         return self._dataset_template.fa
-
 
     def set_output_dataset_attributes(self, ds):
         '''
@@ -946,7 +931,6 @@ class CosmoSearchlight(Searchlight):
     A typical use case is in combination with a neighborhood from CoSMoMVPA,
     either from a .mat matlab file or through a CosmoQueryEngine
     '''
-
 
     def __init__(self, datameasure, nbrhood, add_center_fa=False,
                  results_postproc_fx=None,
@@ -1015,7 +999,6 @@ class CosmoSearchlight(Searchlight):
                                                tmp_prefix=tmp_prefix,
                                                nblocks=nblocks,
                                                **kwargs)
-
 
     def _call(self, ds):
         '''

--- a/mvpa2/datasets/cosmo.py
+++ b/mvpa2/datasets/cosmo.py
@@ -157,6 +157,7 @@ from mvpa2.base.collections import Collection  # ArrayCollectable
 from mvpa2.misc.neighborhood import QueryEngineInterface
 from mvpa2.measures.searchlight import Searchlight
 from mvpa2.base import debug, warning
+from mvpa2.mappers.flatten import FlattenMapper
 
 
 
@@ -326,6 +327,7 @@ def _attributes_dict2cosmo(ds):
             dtypes = []
             values = []
 
+
             for k in attr_collection:
                 value = attr_collection[k].value
 
@@ -358,9 +360,10 @@ def _attributes_dict2cosmo(ds):
 
 
 
-def _mat_replace_matlab_function_by_string(x):
+def _mat_replace_functions_by_string(x):
     '''
-    Replace matlab function handles (as read by matread) by a string.
+    Replace matlab function handles (as read by matread) and FlattenMapper
+    objects by a string.
 
     Parameters
     ----------
@@ -369,24 +372,28 @@ def _mat_replace_matlab_function_by_string(x):
     Returns
     -------
     y : object
-        if x is a scipy.io.matlab.mio5_params.MatlabFunction then
+        if x is a scipy.io.matlab.mio5_params.MatlabFunction or
+        an mvpa2.mappers.flatten.FlattenMapper instance, then
         y is a string representation of x, otherwise y is equal to x
 
     Notes
     -----
-    scipy can read but not write Matlab function hanndles; the use case of
+    scipy can read but not write Matlab function handles; the use case of
     this function is to replace such function handles by something that scipy
     can write
     '''
 
-    if isinstance(x, matlab.mio5_params.MatlabFunction):
+    unsupported_classes=(matlab.mio5_params.MatlabFunction,
+                         FlattenMapper)
+
+    if isinstance(x, unsupported_classes):
         return np.asarray('%s' % x)
 
     return None
 
 
 
-def _mat_make_saveable(x, fixer=_mat_replace_matlab_function_by_string):
+def _mat_make_saveable(x, fixer=_mat_replace_functions_by_string):
     '''
     Make a Matlab data structure saveable by scipy's matsave
 

--- a/mvpa2/tests/test_cosmo.py
+++ b/mvpa2/tests/test_cosmo.py
@@ -366,8 +366,9 @@ def test_fmri_to_cosmo():
     skip_if_no_external('nibabel')
     from mvpa2.datasets.mri import fmri_dataset
     # test exporting an fMRI dataset to CoSMoMVPA
-    pymvpa_ds = fmri_dataset(samples=pathjoin(pymvpa_dataroot, 'example4d.nii.gz'),
-                      targets=[1, 2], sprefix='voxel')
+    pymvpa_ds = fmri_dataset(
+        samples=pathjoin(pymvpa_dataroot, 'example4d.nii.gz'),
+        targets=[1, 2], sprefix='voxel')
     cosmomvpa_struct = cosmo.map2cosmo(pymvpa_ds)
     _assert_set_equal(cosmomvpa_struct.keys(), ['a', 'fa', 'sa', 'samples'])
 
@@ -385,8 +386,8 @@ def test_fmri_to_cosmo():
 
         assert_array_almost_equal(c_value, p_value)
 
-    fa_dict=dict(_obj2tup(cosmomvpa_struct['fa']))
-    fa_keys=['voxel_indices']
-    _assert_set_equal(fa_dict.keys(),fa_keys)
+    fa_dict = dict(_obj2tup(cosmomvpa_struct['fa']))
+    fa_keys = ['voxel_indices']
+    _assert_set_equal(fa_dict.keys(), fa_keys)
     for k in fa_keys:
         assert_array_almost_equal(fa_dict[k].T, pymvpa_ds.fa[k].value)

--- a/mvpa2/tests/test_cosmo.py
+++ b/mvpa2/tests/test_cosmo.py
@@ -10,18 +10,22 @@
 """Unit tests for CoSMoMVPA dataset (http://cosmomvpa.org)"""
 
 from mvpa2.testing.tools import assert_raises, ok_, assert_true, \
-    assert_equal, assert_array_equal, with_tempfile
+    assert_equal, assert_array_equal, assert_array_almost_equal, \
+    with_tempfile
 from mvpa2.testing import skip_if_no_external
 
 skip_if_no_external('scipy')
 from scipy.io import loadmat, savemat, matlab
 from mvpa2.datasets import cosmo
+from mvpa2 import pymvpa_dataroot
 
 from mvpa2.measures.base import Measure
 from mvpa2.datasets.base import Dataset
 from mvpa2.mappers.fx import mean_feature
 
 import numpy as np
+
+from os.path import join as pathjoin
 
 arr = np.asarray
 
@@ -40,6 +44,29 @@ def _tup2obj(tuples):
         values.append(v)
 
     return np.array([[tuple(values)]], dtype=np.dtype(dtypes))
+
+
+
+def _obj2tup(obj):
+    # obj is an object array from scipy Matlab data structure
+    names = obj.dtype.names
+
+    if names is None:
+        # not an object array
+        return None
+
+    tups = []
+
+    if obj.shape != (1, 1):
+        raise ValueError('Unsupported non-singleton shape')
+
+    for k in names:
+        # get singleton element out
+        tup = (k, obj[0, 0][k])
+
+        tups.append(tup)
+
+    return tups
 
 
 
@@ -118,7 +145,7 @@ def _create_small_mat_nbrhood_dict():
 
     # XXX in the future we may want to use a real origin with
     # contents of .a and .fa taken from the dataset
-    origin = ('unused',0)
+    origin = ('unused', 0)
 
     return dict(neighbors=neighbors, fa=fa, a=a, origin=origin)
 
@@ -168,6 +195,12 @@ def _assert_array_collectable_equal(x, y):
     # test for keys and values equal in x and y
     _assert_array_collectable_less_or_equal(x, y)
     _assert_array_collectable_less_or_equal(y, x)
+
+
+
+def _assert_subset(x, y):
+    # test that first argument is a subset of the second
+    assert_true(set(x).issubset(set(y)))
 
 
 
@@ -326,3 +359,34 @@ def test_cosmo_repr_and_str():
         for fmt in 'rs':
             obj_str = (("%%%s" % fmt) % obj)
             assert_true(obj.__class__.__name__ in obj_str)
+
+
+
+def test_fmri_to_cosmo():
+    skip_if_no_external('nibabel')
+    from mvpa2.datasets.mri import fmri_dataset
+    # test exporting an fMRI dataset to CoSMoMVPA
+    pymvpa_ds = fmri_dataset(samples=pathjoin(pymvpa_dataroot, 'example4d.nii.gz'),
+                      targets=[1, 2], sprefix='voxel')
+    cosmomvpa_struct = cosmo.map2cosmo(pymvpa_ds)
+    _assert_set_equal(cosmomvpa_struct.keys(), ['a', 'fa', 'sa', 'samples'])
+
+    a_dict = dict(_obj2tup(cosmomvpa_struct['a']))
+    mri_keys = ['imgaffine', 'voxel_eldim', 'voxel_dim']
+    _assert_subset(mri_keys, a_dict.keys())
+
+    for k in mri_keys:
+        c_value = a_dict[k]
+        p_value = pymvpa_ds.a[k].value
+
+        if isinstance(p_value, tuple):
+            c_value = c_value.ravel()
+            p_value = np.asarray(p_value).ravel()
+
+        assert_array_almost_equal(c_value, p_value)
+
+    fa_dict=dict(_obj2tup(cosmomvpa_struct['fa']))
+    fa_keys=['voxel_indices']
+    _assert_set_equal(fa_dict.keys(),fa_keys)
+    for k in fa_keys:
+        assert_array_almost_equal(fa_dict[k].T, pymvpa_ds.fa[k].value)


### PR DESCRIPTION
WiP for #430 (@mvdoc @snastase). This first step allows exporting an fMRI dataset created in PyMVPA to CoSMoMVPA.

TODO for this PR: update CoSMoMVPA's ``cosmo_fmri_dataset`` so that the resulting struct can be read in CoSMoMVPA directly.

Roadmap: 
- implement i/o for the reverse way, i.e. allow an fmri dataset from CoSMoMVPA to be imported in PyMVPA, and be recognized as nifti-like frmi-dataset
- to do same for surface-based data (bi-directional)
