### PR TITLE
ENH: use rsync syntax compatible with what is present on OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,10 @@ WWW_UPLOAD_URI_DEV=dev.pymvpa.org:/home/www/dev.pymvpa.org/pymvpa
 DATA_HOST=data.pymvpa.org
 DATA_DIR=datadb
 DATA_SUBDIRS='$(DATA_DIR)/tutorial_data \
-				 $(DATA_DIR)/mnist \
-				 $(DATA_DIR)/face_inversion_demo \
-				 $(DATA_DIR)/hyperalignment_tutorial_data \
-				 $(DATA_DIR)/haxby2001'
+                  $(DATA_DIR)/mnist \
+                  $(DATA_DIR)/face_inversion_demo \
+                  $(DATA_DIR)/hyperalignment_tutorial_data \
+                  $(DATA_DIR)/haxby2001'
 DATA_UPLOAD_URI=$(DATA_HOST):/home/www/data.pymvpa.org/www/datasets
 SWARMTOOL_DIR=tools/codeswarm
 SWARMTOOL_DIRFULL=$(CURDIR)/$(SWARMTOOL_DIR)
@@ -713,8 +713,7 @@ bdist_mpkg: 3rd
 fetch-data:
 	echo "I: fetching data from datadb"
 	[ -e datadb ] || mkdir -p datadb
-	rsync $(RSYNC_OPTS) $(DATA_HOST)::$(DATA_SUBDIRS) \
-				$(DATA_DIR)/
+	rsync $(RSYNC_OPTS) $(DATA_HOST)::$(DATA_SUBDIRS) $(DATA_DIR)/
 	for ds in datadb/*; do \
 		echo " I: looking at $$ds"; \
 		cd $(CURDIR)/$${ds} && \

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,11 @@ WWW_UPLOAD_URI=www.pymvpa.org:/home/www/www.pymvpa.org/pymvpa
 WWW_UPLOAD_URI_DEV=dev.pymvpa.org:/home/www/dev.pymvpa.org/pymvpa
 DATA_HOST=data.pymvpa.org
 DATA_DIR=datadb
+DATA_SUBDIRS='$(DATA_DIR)/tutorial_data \
+				 $(DATA_DIR)/mnist \
+				 $(DATA_DIR)/face_inversion_demo \
+				 $(DATA_DIR)/hyperalignment_tutorial_data \
+				 $(DATA_DIR)/haxby2001'
 DATA_UPLOAD_URI=$(DATA_HOST):/home/www/data.pymvpa.org/www/datasets
 SWARMTOOL_DIR=tools/codeswarm
 SWARMTOOL_DIRFULL=$(CURDIR)/$(SWARMTOOL_DIR)
@@ -708,7 +713,7 @@ bdist_mpkg: 3rd
 fetch-data:
 	echo "I: fetching data from datadb"
 	[ -e datadb ] || mkdir -p datadb
-	rsync $(RSYNC_OPTS) $(DATA_HOST)::'$(DATA_DIR)/tutorial_data $(DATA_DIR)/mnist $(DATA_DIR)/face_inversion_demo $(DATA_DIR)/hyperalignment_tutorial_data $(DATA_DIR)/haxby2001' \
+	rsync $(RSYNC_OPTS) $(DATA_HOST)::$(DATA_SUBDIRS) \
 				$(DATA_DIR)/
 	for ds in datadb/*; do \
 		echo " I: looking at $$ds"; \

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,9 @@ WWW_DIR=$(BUILDDIR)/website
 SWARM_DIR=$(BUILDDIR)/swarm
 WWW_UPLOAD_URI=www.pymvpa.org:/home/www/www.pymvpa.org/pymvpa
 WWW_UPLOAD_URI_DEV=dev.pymvpa.org:/home/www/dev.pymvpa.org/pymvpa
-DATA_UPLOAD_URI=data.pymvpa.org:/home/www/data.pymvpa.org/www/datasets
-DATA_URI=data.pymvpa.org::datadb
+DATA_HOST=data.pymvpa.org
+DATA_DIR=datadb
+DATA_UPLOAD_URI=$(DATA_HOST):/home/www/data.pymvpa.org/www/datasets
 SWARMTOOL_DIR=tools/codeswarm
 SWARMTOOL_DIRFULL=$(CURDIR)/$(SWARMTOOL_DIR)
 RSYNC_OPTS=-az -H --no-perms --no-owner --verbose --progress --no-g --exclude prev/
@@ -707,12 +708,9 @@ bdist_mpkg: 3rd
 fetch-data:
 	echo "I: fetching data from datadb"
 	[ -e datadb ] || mkdir -p datadb
-	rsync $(RSYNC_OPTS) $(DATA_URI)/tutorial_data $(DATA_URI)/mnist \
-		$(DATA_URI)/face_inversion_demo \
-	      	$(DATA_URI)/hyperalignment_tutorial_data \
-                $(DATA_URI)/haxby2001 \
-		datadb/ 
-	@for ds in datadb/*; do \
+	rsync $(RSYNC_OPTS) $(DATA_HOST)::'$(DATA_DIR)/tutorial_data $(DATA_DIR)/mnist $(DATA_DIR)/face_inversion_demo $(DATA_DIR)/hyperalignment_tutorial_data $(DATA_DIR)/haxby2001' \
+				$(DATA_DIR)/
+	for ds in datadb/*; do \
 		echo " I: looking at $$ds"; \
 		cd $(CURDIR)/$${ds} && \
 		md5sum -c MD5SUMS && \


### PR DESCRIPTION
on OSX, the syntax::

    rsync HOST::SRC1 HOST::SRC2 TRG 

is not supported; instead::

    rsync HOST::'SRC1 SRC2' TRG

must be used. This PR updates the ``fetch-data`` option in the Makefile that used the unsupported syntax.

(Unfortunately I did not find a way to split the source line into multiple lines)