### PR TITLE
BF(workaround): numpy 1:1.11.0~b3-1+b1 manages to get corrcoef > 1

### DIFF
--- a/mvpa2/tests/test_searchlight.py
+++ b/mvpa2/tests/test_searchlight.py
@@ -582,8 +582,9 @@ class SearchlightTests(unittest.TestCase):
 
         def corr12(ds):
             corr = np.corrcoef(ds.samples)
-            assert(corr.shape == (2, 2)) # for paranoid ones
-            return corr[0, 1]
+            assert(corr.shape == (2, 2))  # for paranoid ones
+            # numpy 1.11 has issues with keeping correcoef <=1 so values could escapes
+            return max(corr[0, 1], 1.0)
 
         for nsc, thr, thr_mean in (
             (0, 1.0, 1.0),


### PR DESCRIPTION
just a tiny bit, but still:

```
> python -c 'import numpy as np; d = np.random.normal(size=(100, 100)).astype(np.float64); print (np.max(np.corrcoef(d)) - 1.0)'
2.22044604925e-16
```
so causes tests to fail.  yet to check if master numpy fixed