### PR TITLE
ENH: skip testing AUC on KNN based classifiers 

### DIFF
--- a/mvpa2/tests/test_transerror.py
+++ b/mvpa2/tests/test_transerror.py
@@ -272,14 +272,13 @@ class ErrorsTests(unittest.TestCase):
                              num_perm - cvte.null_dist.ca.skipped)
 
 
-
     @sweepargs(clf=clfswh['multiclass'])
     def test_auc(self, clf):
         """Test AUC computation
         """
-        if isinstance(clf, MulticlassClassifier):
-            raise SkipTest, \
-                  "TODO: handle values correctly in MulticlassClassifier"
+        if isinstance(clf, MulticlassClassifier) or '<kNN' in str(clf):
+            raise SkipTest(
+                  "TODO: handle values correctly in %s" % clf)
         clf.ca.change_temporarily(enable_ca = ['estimates'])
         if 'qda' in clf.__tags__:
             # for reliable estimation of covariances, need sufficient


### PR DESCRIPTION
since we ruined our ad-hoc support for it in adf13478a4628c0f04b63eabd1cb405d45175a7d