### PR TITLE
BF: free up svm model's vectors correctly (Closes #443)

### DIFF
--- a/mvpa2/clfs/libsvmc/_svm.py
+++ b/mvpa2/clfs/libsvmc/_svm.py
@@ -254,9 +254,9 @@ class SVMProblem:
         if svmc is not None:
             svmc.delete_double(self.y_array)
         for i in range(self.size):
-            if self.data:
-                del self.data[0]
-            #svmc.svm_node_array_destroy(self.data[i])
+            svmc.svm_node_array_destroy(self.data[i])
+        svmc.svm_node_matrix_destroy(self.x_matrix)
+        del self.data
         del self.x_matrix
 
 
@@ -418,6 +418,7 @@ class SVMModel:
                    and svmc.__version__ or "unknown",
                    `self`))
         try:
+            svmc.svm_destroy_model_helper(self.model)
             del self.model
         except Exception, e:
             # blind way to overcome problem of already deleted model and


### PR DESCRIPTION
May be added few not really needed double free ups 'just incase' and a
unittest for the leak.   Thanks Laurens Berthold (@bertholdl) for the very nice report