### PR TITLE
BF: loosening some stringent tests and some PEP8

### DIFF
--- a/mvpa2/tests/test_searchlight_hyperalignment.py
+++ b/mvpa2/tests/test_searchlight_hyperalignment.py
@@ -242,7 +242,7 @@ class SearchlightHyperalignmentTests(unittest.TestCase):
             max_weight = proj[0].proj.toarray().max(0).squeeze()
             diag_weight = proj[0].proj.diagonal()
             # Check to make sure diagonal is the max weight, in almost all rows for reference subject
-            assert(np.sum(max_weight == diag_weight) / float(len(diag_weight)) > 0.98)
+            assert(np.sum(max_weight == diag_weight) / float(len(diag_weight)) > 0.90)
             # and not true for other subjects
             for i in range(1, nds - 1):
                 assert(np.sum(proj[i].proj.toarray().max(0).squeeze() == proj[i].proj.diagonal())
@@ -251,7 +251,7 @@ class SearchlightHyperalignmentTests(unittest.TestCase):
             max_weight = proj[-1].proj.toarray().max(0).squeeze()
             diag_weight = proj[-1].proj.diagonal()
             # Check to make sure diagonal is the max weight, in almost all rows for reference subject
-            assert(np.sum(max_weight == diag_weight) / float(len(diag_weight)) > 0.95)
+            assert(np.sum(max_weight == diag_weight) / float(len(diag_weight)) > 0.90)
         # project data
         dss_hyper = [hm.forward(sd) for hm, sd in zip(projs[0], dss)]
         _ = [zscore(sd, chunks_attr=None) for sd in dss_hyper]
@@ -278,7 +278,6 @@ class SearchlightHyperalignmentTests(unittest.TestCase):
         # TODO: we need assert_warnings to also capture our own warnings,
         # currently they are just suppressed :-/  So this is just a smoke test
         mappers = slhyper([ds_orig, ds_orig.copy()])
-
 
     @reseed_rng()
     def test_custom_qas(self):
@@ -310,7 +309,8 @@ class SearchlightHyperalignmentTests(unittest.TestCase):
         assert_array_equal(projs[0], tprojs_shifted[0])  # must be identity since we made them so
         assert_array_equal(projs[1], tprojs_shifted[1])  # pretty much incorporating that shift
 
-        # TODO -- not identity assert_array_equal(projs[0], np.eye(len(p)))  # must be identity since we made them so
+        # TODO -- not identity assert_array_equal(projs[0], np.eye(len(p)))
+        #  must be identity since we made them so
         # and must restore data properly
         assert_array_almost_equal(mappers[0].forward(ds0), mappers[1].forward(ds1))
 
@@ -353,19 +353,12 @@ class SearchlightHyperalignmentTests(unittest.TestCase):
         projs = apply_slhyper(qe0)
         # Test that in general we get larger coefficients for "correct" transformation
         for p, tproj in zip(projs, tprojs_shifted):
-            #print np.round(p, decimals=3)
-            #print np.asarray(p)[tproj>0]
-            assert(np.all(np.asarray(p)[tproj>0] >= 1.0)) # .astype(int), tproj)
-            #print np.asarray(p)[tproj==0]
-            assert_array_lequal(np.mean(np.asarray(p)[tproj==0]), 0.3)
+            assert(np.all(np.asarray(p)[tproj>0] >= 1.0))  # .astype(int), tproj)
+            assert_array_lequal(np.mean(np.asarray(p)[tproj == 0]), 0.3)
 
         qe1 = FancyQE([[0, 1, 2, 3], [1, 2, 3], [2, 3], [3]])
         # Just a smoke test, for now TODO
         projs = apply_slhyper([qe0, qe1])
-        # print
-        # for p, tproj in zip(projs, tprojs_shifted):
-        #     print np.round(p, decimals=3)
-
 
 
 def assert_no_offdiag(a):
@@ -374,6 +367,7 @@ def assert_no_offdiag(a):
             assert_no_offdiag(a_)
     else:
         assert_array_equal(a - np.diag(np.diagonal(a)), 0)
+
 
 class FancyQE(object):
     """Little helper QE which knows what to return for neighbors"""
@@ -394,6 +388,7 @@ class FancyQE(object):
 
     def __getitem__(self, i):
         return self.results[i]
+
 
 def suite():  # pragma: no cover
     return unittest.makeSuite(SearchlightHyperalignmentTests)


### PR DESCRIPTION
Addressing issue #455 reported by @nno. 
Current codes needs every feature to have max weight for the same feature in ref_ds in projection matrix, but with certain cases such as when combine_neighborhood=False, or if features are correlated to begin with, it might be too stringent. So, this commit allows for room of at most one feature can be different. @yoh this might be important in the context of daily tests.