### PR TITLE
BF: replace lambdas with defined helper functions to allow to h5save hyperalignments

### DIFF
--- a/mvpa2/algorithms/hyperalignment.py
+++ b/mvpa2/algorithms/hyperalignment.py
@@ -38,7 +38,21 @@ from mvpa2.support.due import due, Doi
 if __debug__:
     from mvpa2.base import debug
 
-__all__ = [ "Hyperalignment" ]
+__all__ = ["Hyperalignment"]
+
+#
+# Helper functions which will be used as defaults for Hyperalignment parameters
+# to avoid lambdas (we fail to serialize them ATM in h5save) and to
+# provide easier to comprehend repr of their values
+#
+
+def mean_xy(x, y):
+    return 0.5 * (x + y)
+
+
+def mean_axis0(a):
+    return np.mean(a, axis=0)
+
 
 class Hyperalignment(ClassWithCollections):
     """Align the features across multiple datasets into a common feature space.
@@ -143,7 +157,7 @@ class Hyperalignment(ClassWithCollections):
             doc="""Flag to Z-score the common space after each adjustment.
                 This should be left enabled in most cases.""")
 
-    combiner1 = Parameter(lambda x,y: 0.5*(x+y), #
+    combiner1 = Parameter(mean_xy,  #
             doc="""How to update common space in the 1st-level loop. This must
                 be a callable that takes two arguments. The first argument is
                 one of the input datasets after projection onto the 1st-level
@@ -153,7 +167,7 @@ class Hyperalignment(ClassWithCollections):
                 By default the new common space is the average of the current
                 common space and the recently projected dataset.""")
 
-    combiner2 = Parameter(lambda l: np.mean(l, axis=0),
+    combiner2 = Parameter(mean_axis0,
             doc="""How to combine all individual spaces to common space. This
             must be a callable that take a sequence of datasets as an argument.
             The callable must return a single array. This combiner is called

--- a/mvpa2/tests/test_searchlight_hyperalignment.py
+++ b/mvpa2/tests/test_searchlight_hyperalignment.py
@@ -174,7 +174,8 @@ class SearchlightHyperalignmentTests(unittest.TestCase):
         assert(np.alltrue([np.sum(m[7, :] == 0) == 4 for m in mappers_fsf]))
 
     @reseed_rng()
-    def test_searchlight_hyperalignment(self):
+    @with_tempfile('.hdf5')
+    def test_searchlight_hyperalignment(self, tempfile):
         skip_if_no_external('scipy')
         skip_if_no_external('h5py')
         ds_orig = datasets['3dsmall'].copy()[:, :15]
@@ -228,6 +229,7 @@ class SearchlightHyperalignmentTests(unittest.TestCase):
             # one mapper per input ds
             assert_equal(len(mappers), nds)
             projs.append(mappers)
+
         # some checks
         for midx in range(nds):
             # making sure mask_node_ids options works as expected
@@ -254,6 +256,7 @@ class SearchlightHyperalignmentTests(unittest.TestCase):
             diag_weight = proj[-1].proj.diagonal()
             # Check to make sure diagonal is the max weight, in almost all rows for reference subject
             assert(np.sum(max_weight == diag_weight) / float(len(diag_weight)) >= 0.80)
+
         # project data
         dss_hyper = [hm.forward(sd) for hm, sd in zip(projs[0], dss)]
         _ = [zscore(sd, chunks_attr=None) for sd in dss_hyper]
@@ -268,6 +271,13 @@ class SearchlightHyperalignmentTests(unittest.TestCase):
         # noisy copy of original dataset should be similar to original after hyperalignment
         assert_true(np.median(ndcss[-1]) > 0.9)
         assert_true(np.all([np.median(ndcs) > 0.2 for ndcs in ndcss[1:-2]]))
+
+        # just a single test to verify that we can save hyperalignment instances
+        try:
+            from mvpa2.base.hdf5 import h5save
+        except ImportError:
+            raise SkipTest("h5save of hyperalignment")
+        h5save(tempfile, slhyp)
 
     @reseed_rng()
     def test_searchlight_hyperalignment_warnings_and_exceptions(self):


### PR DESCRIPTION
Rather a workaround than a proper fix (to serialize and save lambdas, at least the ones without closures)

Closes #491