### PR TITLE
Ran into the issue that ENET crashed (within R), because target names…

### DIFF
--- a/mvpa2/clfs/enet.py
+++ b/mvpa2/clfs/enet.py
@@ -131,11 +131,9 @@ class ENET(Classifier):
     def _train(self, data):
         """Train the classifier using `data` (`Dataset`).
         """
-        data.targets = self._attrmap.to_numeric(data.sa[self.get_space()].value)
-        if set(data.targets) != set([0, 1]):
-            raise ValueError, \
-                "Regressors for logistic regression should be [0,1]. Got %s" \
-                % (set(data.targets),)
+        # R enet expects targets to be numerical values
+        if data.uniquetargets.dtype.type is np.string_:
+            data.targets = self._attrmap.to_numeric(data.sa[self.get_space()].value)
         targets = data.sa[self.get_space()].value[:, np.newaxis]
         enet_kwargs = {}
         if self.__max_steps is not None:

--- a/mvpa2/clfs/enet.py
+++ b/mvpa2/clfs/enet.py
@@ -131,6 +131,11 @@ class ENET(Classifier):
     def _train(self, data):
         """Train the classifier using `data` (`Dataset`).
         """
+        data.targets = self._attrmap.to_numeric(data.sa[self.get_space()].value)
+        if set(data.targets) != set([0, 1]):
+            raise ValueError, \
+                "Regressors for logistic regression should be [0,1]. Got %s" \
+                % (set(data.targets),)
         targets = data.sa[self.get_space()].value[:, np.newaxis]
         enet_kwargs = {}
         if self.__max_steps is not None:


### PR DESCRIPTION
Ran into the issue that ENET crashed (within R), because target names were strings in my dataset, rather that 0/1. This patch fixed it, but somebody who knows something should probably make sure this is indeed the proper way of dealing with the situation. Specifically, I am pretty sure that this type casting doesn't affect the original data, which is passed as arg to _train, but I am not sure whether this would always be the case, or whether "data" is sometimes passed as reference.