### PR TITLE
NF: Log and apply selections

### DIFF
--- a/mvpa2/generators/resampling.py
+++ b/mvpa2/generators/resampling.py
@@ -210,8 +210,9 @@ class Balancer(Node):
 class LogExclusions(Node):
     """Log excluded entries
 
-    Given a dataset with a boolean sample or feature attribute, return a
-    dataset with only those samples/features marked `True`.
+    Given a dataset with a boolean sample or feature attribute, log the entries
+    that are excluded (marked `False`).
+    Returns an unmodified dataset.
     """
     def __init__(self, fname, append=True, space='balanced_set', **kwargs):
         """
@@ -221,7 +222,7 @@ class LogExclusions(Node):
           Name of the selection marker attribute in the input dataset that
           indicates the desired subset.
         """
-        Node.__init__(self, space=space, **kwargs)
+        super(LogExclusions, self).__init__(space=space, **kwargs)
         self._fname = fname
         # Truncate at start, append otherwise, to avoid holding an open
         # filehandle throughout execution
@@ -271,7 +272,7 @@ class ApplySelection(Node):
           Name of the selection marker attribute in the input dataset that
           indicates the desired subset.
         """
-        Node.__init__(self, space=space, **kwargs)
+        super(ApplySelection, self).__init__(space=space, **kwargs)
 
     def _call(self, ds):
         space = self.get_space()


### PR DESCRIPTION
Following on #493, I've found these useful for debugging and verification of Balancer selections.

Example usage:

``` Python
balancer = Balancer(..., apply_selection=False)
logger = LogExclusions(log_file)
partitioner = ChainNode([NFoldPartitioner(), balancer, logger, ApplySelection()],
                        space='partitions')
```

Any interest in including either of these?
