### PR TITLE
BF: Fix a bug with computing edge lengths.

### DIFF
--- a/mvpa2/support/nibabel/surf.py
+++ b/mvpa2/support/nibabel/surf.py
@@ -155,12 +155,10 @@ class Surface(object):
             sum_dist = np.zeros((n,))
             count_dist = np.zeros((n,))
             a = f[:, 0]
-            p = v[a]
             for j in xrange(3):
                 b = f[:, (j + 1) % 3]
-                q = v[b]
 
-                d = np.sum((p - q) ** 2, 1) ** .5
+                d = np.sum((v[a] - v[b]) ** 2, 1) ** .5
 
                 count_dist[a] += 1
                 count_dist[b] += 1


### PR DESCRIPTION
Fix a bug where `p` (or `v[a]`) doesn't update in the for loop.
With this bug, the code actually compute distance between nodes `(0, 1)`, `(0, 2)`, and `(0, 0)` of each face, whereas they should be `(0, 1)`, `(1, 2)`, and `(2, 0)`.
The computed distances (edge lengths) would be underestimated because some of the computed distances are always 0.