### PR TITLE
NF: Added dimensionality reduction using SVD to Hyperalignment.

### DIFF
--- a/mvpa2/algorithms/hyperalignment.py
+++ b/mvpa2/algorithms/hyperalignment.py
@@ -190,7 +190,7 @@ class Hyperalignment(ClassWithCollections):
         # Initializing here so that call can access it without passing after train.
         # Moreover, it is similar to commonspace, in that, it is required for mapping
         # new subjects
-        self.svd_mapper = None
+        self._svd_mapper = None
 
 
     @due.dcite(
@@ -301,9 +301,10 @@ class Hyperalignment(ClassWithCollections):
                                             residuals)
         if params.output_dim is not None:
             mappers = self._level3(datasets)
-            self.svd_mapper = SVDMapper()
-            self.svd_mapper.train(self._map_and_mean(datasets, mappers))
-            self.svd_mapper = StaticProjectionMapper(proj=self.svd_mapper.proj[:, :params.output_dim])
+            self._svd_mapper = SVDMapper()
+            self._svd_mapper.train(self._map_and_mean(datasets, mappers))
+            self._svd_mapper = StaticProjectionMapper(
+                proj=self._svd_mapper.proj[:, :params.output_dim])
 
     def __call__(self, datasets):
         """Derive a common feature space from a series of datasets.
@@ -360,9 +361,9 @@ class Hyperalignment(ClassWithCollections):
             else:
                 mappers = [ChainMapper([zm, m]) for zm, m in zip(zmappers, mappers)]
         elif params.alpha < 1:
-                mappers = [ChainMapper([wm, m]) for wm, m in zip(wmappers, mappers)]
+            mappers = [ChainMapper([wm, m]) for wm, m in zip(wmappers, mappers)]
         if params.output_dim is not None:
-            mappers = [ChainMapper([m, self.svd_mapper]) for m in mappers]
+            mappers = [ChainMapper([m, self._svd_mapper]) for m in mappers]
         return mappers
 
 

--- a/mvpa2/algorithms/hyperalignment.py
+++ b/mvpa2/algorithms/hyperalignment.py
@@ -32,6 +32,7 @@ from mvpa2.datasets import Dataset
 from mvpa2.mappers.base import ChainMapper
 from mvpa2.mappers.zscore import zscore, ZScoreMapper
 from mvpa2.mappers.staticprojection import StaticProjectionMapper
+from mvpa2.mappers.svd import SVDMapper
 
 from mvpa2.support.due import due, Doi
 
@@ -130,6 +131,12 @@ class Hyperalignment(ClassWithCollections):
             `None` (default) an instance of
             :class:`~mvpa2.mappers.procrustean.ProcrusteanMapper` is
             used.""")
+    output_dim = Parameter(None, constraints=(EnsureInt() & EnsureRange(min=1)| EnsureNone()),
+            doc="""Output common space dimensionality. If None, datasets are aligned
+             to the features of the `ref_ds`. Otherwise, dimensionality reduction is
+             performed using SVD and only the top SVs are kept. To get all features in
+             SVD-aligned space, give output_dim>=nfeatures.
+            """)
 
     alpha = Parameter(1, constraints=EnsureFloat() & EnsureRange(min=0, max=1),
             doc="""Regularization parameter to traverse between (Shrinkage)-CCA
@@ -179,6 +186,7 @@ class Hyperalignment(ClassWithCollections):
     def __init__(self, **kwargs):
         ClassWithCollections.__init__(self, **kwargs)
         self.commonspace = None
+        self.svm = None
 
 
     @due.dcite(
@@ -287,7 +295,11 @@ class Hyperalignment(ClassWithCollections):
             # this is the final common space
             self.commonspace = self._level2(datasets, lvl1_projdata, mappers,
                                             residuals)
-
+        if params.output_dim is not None:
+            mappers = self._level3(datasets)
+            self.svm = self._reduce_svd(self._map_and_mean(datasets, mappers))
+            #self.svm = self._reduce_svd(self.commonspace)
+            self.svm = StaticProjectionMapper(proj=self.svm.proj[:, :params.output_dim])
 
     def __call__(self, datasets):
         """Derive a common feature space from a series of datasets.
@@ -340,14 +352,15 @@ class Hyperalignment(ClassWithCollections):
             # We need to construct new mappers which would chain
             # zscore and then final transformation
             if params.alpha < 1:
-                return [ChainMapper([zm, wm, m]) for zm, wm, m in zip(zmappers, wmappers, mappers)]
+                mappers = [ChainMapper([zm, wm, m]) for zm, wm, m in zip(zmappers, wmappers, mappers)]
             else:
-                return [ChainMapper([zm, m]) for zm, m in zip(zmappers, mappers)]
-        else:
-            if params.alpha < 1:
-                return [ChainMapper([wm, m]) for wm, m in zip(wmappers, mappers)]
-            else:
-                return mappers
+                mappers = [ChainMapper([zm, m]) for zm, m in zip(zmappers, mappers)]
+        elif params.alpha < 1:
+                mappers = [ChainMapper([wm, m]) for wm, m in zip(wmappers, mappers)]
+        if params.output_dim is not None:
+            mappers = [ChainMapper([m, ZScoreMapper(auto_train=True, force_train=True, chunks_attr=None),
+                                    self.svm]) for m in mappers]
+        return mappers
 
 
     def _regularize(self, datasets, alpha):
@@ -493,3 +506,21 @@ class Hyperalignment(ClassWithCollections):
                 residuals[0, i] = np.linalg.norm(data_mapped - self.commonspace)
 
         return mappers
+
+    def _map_and_mean(self, datasets, mappers):
+        params = self.params
+        data_mapped = [[] for ds in datasets]
+        for i, (m, ds_new) in enumerate(zip(mappers, datasets)):
+            if  __debug__:
+                debug('HPAL_', "Mapping for SVD: ds #%i" % i)
+            ds_ = m.forward(ds_new.samples)
+            zscore(ds_, chunks_attr=None)
+            data_mapped[i] = ds_
+        dss_mean = params.combiner2(data_mapped)
+        return dss_mean
+
+    def _reduce_svd(self, dss_mean):
+        zscore(dss_mean, chunks_attr=None)
+        svd = SVDMapper(force_train=True)
+        svd.train(dss_mean)
+        return svd


### PR DESCRIPTION
As originally published in Haxby et al. (2014), dimensionality reduction using SVD is added after Hyperalignment with extra parameter `output_dim` as input. 
If output_dim is specified, HPAL computes projection to SV space derived from training datasets in addition to mappers to the `ref_ds` space.
@yarikoptic @mih 