### PR TITLE
NF: mean_tpr and mean_fnr errorfxs (might be a better default)

### DIFF
--- a/mvpa2/misc/errorfx.py
+++ b/mvpa2/misc/errorfx.py
@@ -72,6 +72,45 @@ def mismatch_error(predicted, target):
     """
     return np.sum( np.asanyarray(predicted) != target )
 
+
+def mean_tpr(predicted, target):
+    """Mean True Positive Rate (TPR).
+
+    Mean of estimates per each class
+    """
+    if len(predicted) != len(target) or not len(target):
+        raise ValueError(
+            "Both predicted and target should be of the same non-0 length")
+    targets = set(predicted)
+    targets.update(target)
+
+    target = np.asanyarray(target)
+    predicted = np.asanyarray(predicted)
+
+    TPRs = []
+    for t in targets:
+        Pmask = target == t
+        TPmask = predicted[Pmask] == t
+        assert len(TPmask) <= len(Pmask),  "do not see how this could have been violated unless indexing is screwedup..."
+        P = np.sum(Pmask)
+        TP = np.sum(TPmask)
+        if not P:
+            # better be safe than sorry
+            raise ValueError(
+                "For target %s there were only predicted values, but no "
+                "expected ones. TPR is undefined in this case, so use some "
+                "other errorfx if you really need to deal with such data (or "
+                "verify if your shuffling etc is correct)"
+                % str(t)
+            )
+        TPRs.append(float(TP)/P)
+    return np.mean(TPRs)
+
+
+def mean_fnr(predicted, target):
+    """Mean False Negative Rate (FNR) = 1 - TPR"""
+    return 1 - mean_tpr(predicted, target)
+
 def prediction_target_matches(predicted, target):
     """Returns a boolean vector of correctness of predictions"""
     return np.asanyarray(predicted) == target

--- a/mvpa2/tests/test_errorfx.py
+++ b/mvpa2/tests/test_errorfx.py
@@ -11,10 +11,16 @@
 import unittest
 import numpy as np
 
-from mvpa2.testing.tools import ok_, assert_array_equal, assert_true, \
-        assert_false, assert_equal, assert_not_equal, reseed_rng
+from mvpa2.testing.tools import (
+    assert_false, assert_equal, assert_almost_equal, reseed_rng,
+    assert_raises,
+)
 
-from mvpa2.misc.errorfx import auc_error
+from mvpa2.misc.errorfx import (
+    auc_error,
+    mean_tpr, mean_fnr,
+    mean_match_accuracy,
+)
 
 def test_auc_error():
     # two basic cases
@@ -27,3 +33,44 @@ def test_auc_error():
     # ties, e.g. if both labels have the same estimate :-/
     # TODO:
     #assert_equal(auc_error([-1, 1, -1, 1], [0, 0, 1, 1]), 0.5)
+
+
+@reseed_rng()
+def test_mean_tpr_balanced():
+    # in case of the balanced sets we should expect to match mean_match_accuracy
+    for nclass in range(2, 4):
+        for nsample in range(1, 3):
+            target = np.repeat(np.arange(nclass), nsample)
+            # perfect match
+            assert_equal(mean_match_accuracy(target, target), 1.0)
+            assert_equal(mean_tpr(target, target), 1.0)
+            # perfect mismatch -- shift by nsample, so no target matches
+            estimate = np.roll(target, nsample)
+            assert_equal(mean_match_accuracy(target, estimate), 0)
+            assert_equal(mean_tpr(target, estimate), 0)
+            # do few permutations and see if both match
+            for i in range(5):
+                np.random.shuffle(estimate)
+                assert_equal(
+                    mean_tpr(target, estimate),
+                    mean_match_accuracy(target, estimate))
+                assert_almost_equal(
+                    mean_tpr(target, estimate), 1-mean_fnr(target, estimate))
+
+
+def test_mean_tpr():
+    # Let's test now on some disbalanced sets
+    assert_raises(ValueError, mean_tpr, [1], [])
+    assert_raises(ValueError, mean_tpr, [], [1])
+    assert_raises(ValueError, mean_tpr, [], [])
+
+    # now interesting one where there were no target when it was in predicted
+    assert_raises(ValueError, mean_tpr, [1], [0])
+    assert_raises(ValueError, mean_tpr, [0, 1], [0, 0])
+    # but it should be ok to have some targets not present in prediction
+    assert_equal(mean_tpr([0, 0], [0, 1]), .5)
+    # the same regardless how many samples in 0-class, if all misclassified
+    # (winner by # of samples takes all)
+    assert_equal(mean_tpr([0, 0, 0], [0, 0, 1]), .5)
+    # whenever mean-accuracy would be different
+    assert_almost_equal(mean_match_accuracy([0, 0, 0], [0, 0, 1]), 2/3.)


### PR DESCRIPTION
In case of the disbalanced sets of samples, mean of the TPR is a more robust measure, which should be `1/n_classes` by chance (unlike the mean accuracy error which would jump between `1/n_classes` and some number defined by the proportion of samples in the dominating samples class).  I could be wrong, but according to my "notes" from few years back (http://www.pymvpa.org/files/OHBM2015_Halchenko.pdf) some toolkits (PRoNTo, PROBID, TDT) already use it as the main error function to avoid such problems while dealing with disbalanced sets.  In case of the balanced sets, it should produce the same error/accuracy as the mean_accuracy 