### PR TITLE
Bf numpy1.13.1

### DIFF
--- a/mvpa2/base/state.py
+++ b/mvpa2/base/state.py
@@ -486,9 +486,9 @@ class ConditionalAttributesCollection(Collection):
 
         `other` can be a ClassWithCollections object or ConditionalAttributesCollection
         """
-        if enable_ca == None:
+        if enable_ca is None:
             enable_ca = []
-        if disable_ca == None:
+        if disable_ca is None:
             disable_ca = []
         self.__storedTemporarily.append(self.enabled)
         other_ = other

--- a/mvpa2/base/verbosity.py
+++ b/mvpa2/base/verbosity.py
@@ -35,7 +35,7 @@ class Logger(object):
 
         Each hanlder must have write() method implemented
         """
-        if handlers == None:
+        if handlers is None:
             handlers = [stdout]
         self.__close_handlers = []
         self.__handlers = []            # pylint friendliness
@@ -247,7 +247,7 @@ class SetLogger(Logger):
         """
         if register is None:
             register = {}
-        if active == None:
+        if active is None:
             active = []
         Logger.__init__(self, *args, **kwargs)
         self.__printsetid = printsetid
@@ -584,7 +584,7 @@ if __debug__:
             *args, **kwargs
               Passed to SetLogger initialization  XXX
             """
-            if metrics == None:
+            if metrics is None:
                 metrics = []
             SetLogger.__init__(self, *args, **kwargs)
             self.__metrics = []

--- a/mvpa2/clfs/blr.py
+++ b/mvpa2/clfs/blr.py
@@ -92,7 +92,7 @@ class BLR(Classifier):
         train_labels = self._attrmap.to_numeric(data.sa[self.get_space()].value)
         # provide a basic (i.e. identity matrix) and correct prior
         # sigma_p, if not provided before or not compliant to 'data':
-        if self.sigma_p == None: # case: not provided
+        if self.sigma_p is None: # case: not provided
             self.sigma_p = np.eye(data.samples.shape[1]+1)
         elif self.sigma_p.shape[1] != (data.samples.shape[1]+1): # case: wrong dimensions
             self.sigma_p = np.eye(data.samples.shape[1]+1)

--- a/mvpa2/clfs/distance.py
+++ b/mvpa2/clfs/distance.py
@@ -292,7 +292,7 @@ def pnorm_w_python(data1, data2=None, weight=None, p=2,
     use_sq_euclidean : bool
       Either to use squared_euclidean_distance_matrix for computation if p==2
     """
-    if weight == None:
+    if weight is None:
         weight = np.ones(data1.shape[1], 'd')
         pass
 
@@ -300,7 +300,7 @@ def pnorm_w_python(data1, data2=None, weight=None, p=2,
         return np.sqrt(squared_euclidean_distance(data1=data1, data2=data2,
                                                  weight=weight**2))
 
-    if data2 == None:
+    if data2 is None:
         data2 = data1
         pass
 
@@ -372,12 +372,12 @@ if externals.exists('weave') or externals.exists('scipy.weave') :
           Power
         """
 
-        if weight == None:
+        if weight is None:
             weight = np.ones(data1.shape[1], 'd')
             pass
         S1, F1 = data1.shape[:2]
         code = ""
-        if data2 == None or id(data1)==id(data2):
+        if data2 is None or id(data1)==id(data2):
             if not (F1==weight.size):
                 raise ValueError, \
                       "Dataset should have same #columns == #weights. Got " \

--- a/mvpa2/clfs/libsvmc/_svm.py
+++ b/mvpa2/clfs/libsvmc/_svm.py
@@ -46,13 +46,13 @@ def double_array(seq):
 
 ##REF: Name was automagically refactored
 def free_int_array(x):
-    if x != 'NULL' and x != None:
+    if x != 'NULL' and x is not None:
         svmc.delete_int(x)
 
 
 ##REF: Name was automagically refactored
 def free_double_array(x):
-    if x != 'NULL' and x != None:
+    if x != 'NULL' and x is not None:
         svmc.delete_double(x)
 
 
@@ -263,7 +263,7 @@ class SVMProblem:
 
 class SVMModel:
     def __init__(self, arg1, arg2=None):
-        if arg2 == None:
+        if arg2 is None:
             # create model from file
             filename = arg1
             self.model = svmc.svm_load_model(filename)

--- a/mvpa2/clfs/meta.py
+++ b/mvpa2/clfs/meta.py
@@ -85,7 +85,7 @@ class BoostedClassifier(Classifier):
           dict of keyworded arguments which might get used
           by State or Classifier
         """
-        if clfs == None:
+        if clfs is None:
             clfs = []
 
         Classifier.__init__(self, **kwargs)
@@ -518,7 +518,7 @@ class ClassifierCombiner(PredictionsCombiner):
         self.__clf = clf
         """Classifier to train on `variables` ca of provided classifiers"""
 
-        if variables == None:
+        if variables is None:
             variables = ['predictions']
         self.__variables = variables
         """What conditional attributes of the classifiers to use"""
@@ -565,7 +565,7 @@ class CombinedClassifier(BoostedClassifier):
             estimate (which is pretty much what is stored under
             `estimates`)
         """
-        if clfs == None:
+        if clfs is None:
             clfs = []
 
         BoostedClassifier.__init__(self, clfs, **kwargs)

--- a/mvpa2/clfs/similarity.py
+++ b/mvpa2/clfs/similarity.py
@@ -47,7 +47,7 @@ class SingleDimensionSimilarity(Similarity):
         self.d = d
 
     def computed(self, data1, data2=None):
-        if data2 == None: data2 = data1
+        if data2 is None: data2 = data1
         self.similarity_matrix = np.exp(-np.abs(data1[:, self.d],
                                               data2[:, self.d]))
         return self.similarity_matrix
@@ -72,7 +72,7 @@ class StreamlineSimilarity(Similarity):
 
 
     def computed(self, data1, data2=None):
-        if data2 == None:
+        if data2 is None:
             data2 = data1
         self.distance_matrix = np.zeros((len(data1), len(data2)))
 

--- a/mvpa2/clfs/transerror.py
+++ b/mvpa2/clfs/transerror.py
@@ -510,7 +510,7 @@ class ConfusionMatrix(SummaryStatistics):
 
         SummaryStatistics.__init__(self, **kwargs)
 
-        if labels == None:
+        if labels is None:
             labels = []
 
         self.__labels = labels

--- a/mvpa2/datasets/miscfx.py
+++ b/mvpa2/datasets/miscfx.py
@@ -404,7 +404,7 @@ def summary_targets(dataset, targets_attr='targets', chunks_attr='chunks',
             d = {'  ' + name1 : l}
             d.update(dict([ (k, stats[k][i]) for k in stats.keys()]))
             table.append( [ ('%.3g', '%s')[isinstance(d[e], basestring)
-                                           or d[e] == None]
+                                           or d[e] is None]
                             % d[e] for e in entries] )
         return '\nSummary for %s across %s\n' % (name1, name2) \
                + table2string(table)

--- a/mvpa2/featsel/rfe.py
+++ b/mvpa2/featsel/rfe.py
@@ -264,7 +264,7 @@ class RFE(IterativeFeatureSelection):
             ca.history[orig_feature_ids] = step
 
             # Compute sensitivity map
-            if self.__update_sensitivity or sensitivity == None:
+            if self.__update_sensitivity or sensitivity is None:
                 sensitivity = self._fmeasure(wdataset)
                 if len(sensitivity) > 1:
                     raise ValueError(

--- a/mvpa2/measures/irelief.py
+++ b/mvpa2/measures/irelief.py
@@ -60,7 +60,7 @@ class IterativeRelief_Devel(FeaturewiseMeasure):
 
         # Threshold in W changes (stopping criterion for irelief)
         self.threshold = threshold
-        if kernel == None:
+        if kernel is None:
             self.kernel = ExponentialKernel
         else:
             self.kernel = kernel
@@ -97,7 +97,7 @@ class IterativeRelief_Devel(FeaturewiseMeasure):
         """Computes featurewise I-RELIEF weights."""
         samples = dataset.samples
         NS, NF = samples.shape[:2]
-        if self.w_guess == None:
+        if self.w_guess is None:
             self.w = np.ones(NF, 'd')
         # do normalization in all cases to be safe :)
         self.w = self.w/(self.w**2).sum()
@@ -185,7 +185,7 @@ class IterativeReliefOnline_Devel(IterativeRelief_Devel):
         """Computes featurewise I-RELIEF-2 weights. Online version."""
         NS = dataset.samples.shape[0]
         NF = dataset.samples.shape[1]
-        if self.w_guess == None:
+        if self.w_guess is None:
             self.w = np.ones(NF, 'd')
         # do normalization in all cases to be safe :)
         self.w = self.w/(self.w**2).sum()
@@ -332,7 +332,7 @@ class IterativeRelief(FeaturewiseMeasure):
         samples = dataset.samples
         NS, NF = samples.shape[:2]
 
-        if self.w_guess == None:
+        if self.w_guess is None:
             w = np.ones(NF, 'd')
 
         w /= (w ** 2).sum() # do normalization in all cases to be safe :)
@@ -407,7 +407,7 @@ class IterativeReliefOnline(IterativeRelief):
         threshold = self.threshold
         a = self.a
 
-        if self.w_guess == None:
+        if self.w_guess is None:
             w = np.ones(NF, 'd')
 
         # do normalization in all cases to be safe :)

--- a/mvpa2/misc/io/base.py
+++ b/mvpa2/misc/io/base.py
@@ -197,7 +197,7 @@ class ColumnData(dict):
         """
         length = None
         for k in self.keys():
-            if length == None:
+            if length is None:
                 length = len(self[k])
             else:
                 if not len(self[k]) == length:
@@ -354,7 +354,7 @@ class ColumnData(dict):
         with open(filename, 'w') as file_:
 
             # write header
-            if header_order == None:
+            if header_order is None:
                 if self._header_order is None:
                     col_hdr = self.keys()
                 else:

--- a/mvpa2/misc/plot/base.py
+++ b/mvpa2/misc/plot/base.py
@@ -599,7 +599,7 @@ def plot_dataset_chunks(ds, clf_labels=None):
             s = ds_chunk.samples[i]
             l = ds_chunk.targets[i]
             format = ''
-            if clf_labels != None:
+            if clf_labels is not None:
                 if clf_labels[i] != ds_chunk.targets[i]:
                     pl.plot([s[0]], [s[1]], 'x' + labels_map[l])
             pl.text(s[0], s[1], chunk_text, color=labels_map[l],

--- a/mvpa2/misc/plot/erp.py
+++ b/mvpa2/misc/plot/erp.py
@@ -467,7 +467,7 @@ def plot_erps(erps, data=None, ax=None, pre=0.2, post=None,
     def set_limits():
         """Helper to set x and y limits"""
         ax.set_xlim((-pre, post))
-        if ylim != None:
+        if ylim is not None:
             ax.set_ylim(*ylim)
 
     set_limits()

--- a/mvpa2/misc/plot/scatter.py
+++ b/mvpa2/misc/plot/scatter.py
@@ -134,6 +134,18 @@ def plot_scatter(dataXd, mask=None, masked_opacity=0.,
     x, y = datainter = data[:, intersection]
 
     if mask is not None:
+        if mask.size * ntimepoints == intersection.size:
+            # we have got a single mask applicable to both x and y
+            pass
+        elif mask.size * ntimepoints == 2 * intersection.size:
+            # we have got a mask per each, let's get an intersection
+            assert mask.shape[0] == 2, "had to get 1 for x, 1 for y"
+            mask = np.logical_and(mask[0], mask[1])
+        else:
+            raise ValueError(
+                "mask of shape %s. data of shape %s. ntimepoints=%d.  "
+                "Teach me how to apply it" % (mask.shape, data.shape, ntimepoints)
+            )
         # replicate mask ntimepoints times
         mask = np.repeat(mask.ravel(), ntimepoints)[intersection] != 0
         x_masked = x[mask]

--- a/mvpa2/support/_emp_null.py
+++ b/mvpa2/support/_emp_null.py
@@ -383,7 +383,7 @@ class ENN(object):
         ax.set_xticklabels(ax.get_xticks(), fontsize=16)
         ax.set_yticklabels(ax.get_yticks(), fontsize=16)
 
-        if efp != None:
+        if efp is not None:
             ax.plot(self.x, np.minimum(alpha, efp), 'k')
     
 

--- a/mvpa2/support/afni/afni_utils.py
+++ b/mvpa2/support/afni/afni_utils.py
@@ -144,7 +144,7 @@ def which(f, env=None):
         Full path of 'f' if 'f' is executable and in the path, 'f' itself
         if 'f' is a path, None otherwise
     '''
-    if env == None:
+    if env is None:
         env = os.environ
 
     def is_executable(fullpath):

--- a/mvpa2/support/nibabel/afni_suma_1d.py
+++ b/mvpa2/support/nibabel/afni_suma_1d.py
@@ -20,7 +20,7 @@ def write(fnout, data, nodeidxs=None):
     data = np.array(data)
     nv = data.shape[0]
     nt = 1 if data.ndim == 1 else data.shape[1]
-    if nodeidxs != None:
+    if nodeidxs is not None:
         # make space
         alldata = np.zeros((nv, nt + 1))
 

--- a/mvpa2/support/nibabel/surf_fs_asc.py
+++ b/mvpa2/support/nibabel/surf_fs_asc.py
@@ -114,7 +114,7 @@ def write(fn, surface, overwrite=False, comment=None):
         raise Exception("File already exists: %s" % fn)
 
     s = []
-    if comment == None:
+    if comment is None:
         comment = '# Created %s' % str(datetime.datetime.now())
     s.append(comment)
 

--- a/mvpa2/tests/test_datameasure.py
+++ b/mvpa2/tests/test_datameasure.py
@@ -563,8 +563,8 @@ class SensitivityAnalysersTests(unittest.TestCase):
         # which do not require any specific order.
         # And yet due to another issue
         # https://github.com/numpy/numpy/issues/3759
-        # we can't just == None for the bool mask
-        None_fa = np.array([x == None for x in  res.fa.nonbogus_targets])
+        # we can't just is None for the bool mask
+        None_fa = np.array([x is None for x in  res.fa.nonbogus_targets])
         assert_array_equal(res.samples[0, None_fa], [18])
         assert_array_equal(res.samples[0, ~None_fa], [1, 1])
 

--- a/mvpa2/tests/test_giftidataset.py
+++ b/mvpa2/tests/test_giftidataset.py
@@ -34,7 +34,7 @@ from mvpa2.testing import sweepargs
 
 def _get_test_sample_node_data(format_=None):
     # returns test data in various formats
-    if format_ == None:
+    if format_ is None:
         samples = np.asarray(
             [[2.032, -0.892, -0.826, 1.163],
              [0.584, 1.844, 1.166, -0.848],

--- a/mvpa2/tests/test_iohelpers.py
+++ b/mvpa2/tests/test_iohelpers.py
@@ -202,7 +202,7 @@ class IOHelperTests(unittest.TestCase):
                 "We must got column names correctly")
         self.assertTrue(len(attr.r_60_B) == attr.nrows,
                 "We must have got access to column by property")
-        self.assertTrue(attr.toarray() != None,
+        self.assertTrue(attr.toarray() is not None,
                 "We must have got access to column by property")
 
     def testdesign2labels(self):

--- a/mvpa2/tests/test_splitter.py
+++ b/mvpa2/tests/test_splitter.py
@@ -85,8 +85,8 @@ class SplitterTests(unittest.TestCase):
         moresplits = [ list(spl.generate(p)) for p in oes.generate(splits[0][0])]
 
         for split in moresplits:
-            self.assertTrue(split[0] != None)
-            self.assertTrue(split[1] != None)
+            self.assertTrue(split[0] is not None)
+            self.assertTrue(split[1] is not None)
 
 
     def test_half_split(self):
@@ -111,8 +111,8 @@ class SplitterTests(unittest.TestCase):
         moresplits = [ list(spl.generate(p)) for p in hs.generate(splits[0][0])]
 
         for split in moresplits:
-            self.assertTrue(split[0] != None)
-            self.assertTrue(split[1] != None)
+            self.assertTrue(split[0] is not None)
+            self.assertTrue(split[1] is not None)
 
     def test_n_group_split(self):
         """Test NGroupSplitter alongside with the reversal of the
@@ -147,8 +147,8 @@ class SplitterTests(unittest.TestCase):
         moresplits = [ list(spl.generate(p)) for p in hs.generate(splits[0][0])]
 
         for split in moresplits:
-            self.assertTrue(split[0] != None)
-            self.assertTrue(split[1] != None)
+            self.assertTrue(split[0] is not None)
+            self.assertTrue(split[1] is not None)
 
         # now test more groups
         s5 = NGroupPartitioner(5)

--- a/tools/bib2rst_ref.py
+++ b/tools/bib2rst_ref.py
@@ -215,7 +215,7 @@ class BibTeX(dict):
     """
     def __init__(self, filename = None):
 
-        if not filename == None:
+        if not filename is None:
             self.open(filename)
 
         # spaces to be used for indentation
@@ -233,7 +233,7 @@ class BibTeX(dict):
         while 1:
             entry = _bibtex.next(file)
 
-            if entry == None: break
+            if entry is None: break
 
             eprops = {}
 


### PR DESCRIPTION
-  commit 391acd8463d23b171f7fb32731f6a015de8265f4
  
   BF(thanks stringent numpy):  deal with a composite mask (one per x, one per y) for scatter_plot
    
    before numpy allowed the selection mask being smaller than actual
    array, e.g.
    
    np.arange(5)[np.array([True, False, True])]
    
    which is not entirely kosher.  And in our case if both masks were
    provided it did something not entirely kosher I think
    Now it should join both masks into intersection first

- commit 97141ed3f7a538fef3bfa19c9653e80bdfa8adfe

     BF(RF): == None -> is None, != None -> is not None
    
    seems that numpy 1.13.1 stopped tollerating comparing to None and made
    it uniform comparison per each element... so if we would like to really
    compare if anything was set, use "is" not "==" with None
