### PR TITLE
Fix issues with Procrustes transformation

### DIFF
--- a/mvpa2/mappers/procrustean.py
+++ b/mvpa2/mappers/procrustean.py
@@ -173,14 +173,15 @@ class ProcrusteanMapper(ProjectionMapper):
                 # http://en.wikipedia.org/wiki/Orthogonal_Procrustes_problem
                 # for more and info and original references, see
                 # http://dx.doi.org/10.1007%2FBF02289451
-                nsv = len(s)
-                s[:-1] = 1
-                s[-1] = np.linalg.det(T)
-                T = np.dot(U[:, :nsv] * s, Vh)
+                s_new = np.ones_like(s)
+                s_new[-1] = np.linalg.det(T)
+                T = np.dot(Vh.T * s_new, U.T)
 
             # figure out scale and final translation
-            # XXX with reflection False -- not sure if here or there or anywhere...
-            ss = sum(s)
+            if not params.reflection:
+                ss = np.sum(s_new * s)
+            else:
+                ss = np.sum(s)
 
         # if we were to collect standardized distance
         # std_d = 1 - sD**2

--- a/mvpa2/tests/test_procrust.py
+++ b/mvpa2/tests/test_procrust.py
@@ -13,7 +13,6 @@ import unittest
 import numpy as np
 import itertools
 from numpy.linalg import norm
-from scipy.stats import zscore
 from mvpa2.base import externals
 from mvpa2.datasets.base import dataset_wizard
 from mvpa2.testing import *
@@ -121,7 +120,7 @@ class ProcrusteanMapperTests(unittest.TestCase):
         for i in range(rep):
             a = np.random.random((10, 10))
             T = np.linalg.qr(a)[0]
-            d = zscore(np.random.random((10, 10)), axis=0)
+            d = np.random.random((10, 10))
             d2 = np.dot(d, T)
             ds = dataset_wizard(samples=d, targets=d2)
 

--- a/mvpa2/tests/test_procrust.py
+++ b/mvpa2/tests/test_procrust.py
@@ -13,6 +13,7 @@ import unittest
 import numpy as np
 import itertools
 from numpy.linalg import norm
+from scipy.stats import zscore
 from mvpa2.base import externals
 from mvpa2.datasets.base import dataset_wizard
 from mvpa2.testing import *
@@ -115,6 +116,48 @@ class ProcrusteanMapperTests(unittest.TestCase):
                     self.assertTrue(ndsfr <= 1e-12,
                                     msg="%s: Failed to reconstruct into source space correctly."
                                         " normed error=%g" % (sdim, ndsfr))
+
+    def test_reflection(self, rep=10):
+        for i in range(rep):
+            a = np.random.random((10, 10))
+            T = np.linalg.qr(a)[0]
+            d = zscore(np.random.random((10, 10)), axis=0)
+            d2 = np.dot(d, T)
+            ds = dataset_wizard(samples=d, targets=d2)
+
+            norm0 = np.linalg.norm(d - d2)
+
+            mapper = ProcrusteanMapper(scaling=False, reflection=False)
+            mapper.train(ds)
+            norm1 = np.linalg.norm(d - mapper.forward(ds).samples)
+            eps = 1e-7
+            self.assertTrue(norm1 <= norm0 + eps,
+                            msg='Procrustes should reduce difference, '
+                            'but %f > %f' % (norm1, norm0))
+
+            mapper = ProcrusteanMapper(scaling=True, reflection=False)
+            mapper.train(ds)
+            norm2 = np.linalg.norm(d - mapper.forward(ds).samples)
+            self.assertTrue(norm2 <= norm1 + eps,
+                            msg='Procrustes with scaling should work better, '
+                            'but %f > %f' % (norm2, norm1))
+
+            mapper = ProcrusteanMapper(scaling=False, reflection=True)
+            mapper.train(ds)
+            norm3 = np.linalg.norm(d - mapper.forward(ds).samples)
+            self.assertTrue(norm3 <= norm1 + eps,
+                            msg='Procrustes with reflection should work better, '
+                            'but %f > %f' % (norm3, norm1))
+
+            mapper = ProcrusteanMapper(scaling=True, reflection=True)
+            mapper.train(ds)
+            norm4 = np.linalg.norm(d - mapper.forward(ds).samples)
+            self.assertTrue(norm4 <= norm3 + eps,
+                            msg='Procrustes with scaling should work better, '
+                            'but %f > %f' % (norm4, norm3))
+            self.assertTrue(norm4 <= norm2 + eps,
+                            msg='Procrustes with reflection should work better, '
+                            'but %f > %f' % (norm4, norm2))
 
 
 def suite():  # pragma: no cover


### PR DESCRIPTION
The transformation matrix `T` is transposed when reflection is turned off.
The scaling factor `scale` is also incorrect in this case because `s` is modified during the corresponding if statement.

The new test should fail in such cases.