### PR TITLE
ENH: Robustify h5save() in the presence of file locks

### DIFF
--- a/mvpa2/base/hdf5.py
+++ b/mvpa2/base/hdf5.py
@@ -906,7 +906,26 @@ def h5save(filename, data, name=None, mode='w', mkdir=True, **kwargs):
         target_dir = osp.dirname(filename)
         if target_dir and not osp.exists(target_dir):
             os.makedirs(target_dir)
-    hdf = h5py.File(filename, mode)
+
+    retries = 30
+    while retries:
+        try:
+            hdf = h5py.File(filename, mode)
+            break
+        except IOError as e:
+            # sadly this test is not reliable
+            #if e.errno == 11:
+            if retries > 1 and 'resource temporarily unavailable' in str(e):
+                # cannot lock the file: possibly concurrent use, but also
+                # seems to happen spuriously with HDF5 1.10
+                # give it a second and try once more
+                import time
+                time.sleep(1.0)
+                print "'%s' cannot be locked, will try again in a second" % filename
+                retries -= 1
+            else:
+                raise
+
     hdf.attrs.create('__pymvpa_hdf5_version__', '2'.encode())
     hdf.attrs.create('__pymvpa_version__', mvpa2.__version__.encode())
     try:


### PR DESCRIPTION
h5lib 1.10 and beyond lock a file if any process reads or writes it (complete description is here: https://support.hdfgroup.org/HDF5/docNewFeatures/SWMR/Design-HDF5-FileLocking.pdf).

A typical PyMVPA script often has an `h5save()` call at the end to store results. With this new locking behavior, we make a single attempt to save and the entire script crashes if there was a concurrent access at that particular time. This leads to desperation, anger, and unicorns dying each time is happens.

This PR introduces re-trying to obtain a file handler in case it was reported as locked. The present implementation tries a fixed maximum number of 30 times, one second apart. This is of course arbitrary and will not fix the issue in case of large files being written that are also open for read, etc... However, it works for given a poor NFS server a little wiggle room to report a file as unlocked again.

We could also decide to implement completely blocking behavior instead, but I had no juice to think that through and went for this hack instead.