### PR TITLE
Adds searchlight on the surface mesh - using disks instead of spheres

### DIFF
--- a/mvpa2/measures/gnbsearchlight.py
+++ b/mvpa2/measures/gnbsearchlight.py
@@ -14,7 +14,7 @@ __docformat__ = 'restructuredtext'
 import numpy as np
 
 from mvpa2.base.dochelpers import borrowkwargs, _repr_attrs
-from mvpa2.misc.neighborhood import IndexQueryEngine, Sphere
+from mvpa2.misc.neighborhood import IndexQueryEngine, Sphere, Disk
 
 from mvpa2.measures.adhocsearchlightbase import \
      SimpleStatBaseSearchlight, _STATS
@@ -23,7 +23,7 @@ if __debug__:
     from mvpa2.base import debug
     import time as time
 
-__all__ = [ "GNBSearchlight", 'sphere_gnbsearchlight' ]
+__all__ = [ "GNBSearchlight", 'sphere_gnbsearchlight', 'disk_gnbsearchlight' ]
 
 class GNBSearchlight(SimpleStatBaseSearchlight):
     """Efficient implementation of Gaussian Naive Bayes `Searchlight`.
@@ -210,6 +210,55 @@ def sphere_gnbsearchlight(gnb, generator, radius=1, center_ids=None,
     """
     # build a matching query engine from the arguments
     kwa = {space: Sphere(radius)}
+    qe = IndexQueryEngine(**kwa)
+    # init the searchlight with the queryengine
+    return GNBSearchlight(gnb, generator, qe,
+                          roi_ids=center_ids, *args, **kwargs)
+
+
+@borrowkwargs(GNBSearchlight, '__init__', exclude=['roi_ids', 'queryengine'])
+def disk_gnbsearchlight(gnb, generator, radius=0.01, center_ids=None,
+                        coords=None, space='vertex_indices', *args, **kwargs):
+    """Creates a `GNBSearchlight` to assess :term:`cross-validation`
+    classification performance of GNB on all possible disks of a
+    certain size within a dataset.
+
+    The idea of taking advantage of naiveness of GNB for the sake of
+    quick searchlight-ing stems from Francisco Pereira (paper under
+    review).
+
+
+    Parameters
+    ----------
+    radius : float
+      All features within this radius around the center will be part
+      of a disk.
+    center_ids : list of int
+      List of feature ids (not coordinates) the shall serve as disk
+      centers. By default all features will be used (it is passed
+      roi_ids argument for Searchlight).
+    coords : list of float
+      List of feature ids coordinates on the inflated surface.
+    space : str
+      Name of a feature attribute of the input dataset that defines the spatial
+      coordinates of all features.
+    **kwargs
+      In addition this class supports all keyword arguments of
+      :class:`~mvpa2.measures.gnbsearchlight.GNBSearchlight`.
+
+    Notes
+    -----
+    If any `BaseSearchlight` is used as `SensitivityAnalyzer` one has to make
+    sure that the specified scalar `Measure` returns large
+    (absolute) values for high sensitivities and small (absolute) values
+    for low sensitivities. Especially when using error functions usually
+    low values imply high performance and therefore high sensitivity.
+    This would in turn result in sensitivity maps that have low
+    (absolute) values indicating high sensitivities and this conflicts
+    with the intended behavior of a `SensitivityAnalyzer`.
+    """
+    # build a matching query engine from the arguments
+    kwa = {space: Disk(coords, radius)}
     qe = IndexQueryEngine(**kwa)
     # init the searchlight with the queryengine
     return GNBSearchlight(gnb, generator, qe,

--- a/mvpa2/measures/nnsearchlight.py
+++ b/mvpa2/measures/nnsearchlight.py
@@ -14,7 +14,7 @@ __docformat__ = 'restructuredtext'
 import numpy as np
 
 from mvpa2.base.dochelpers import borrowkwargs, _repr_attrs
-from mvpa2.misc.neighborhood import IndexQueryEngine, Sphere
+from mvpa2.misc.neighborhood import IndexQueryEngine, Sphere, Disk
 
 from mvpa2.clfs.distance import squared_euclidean_distance, one_minus_correlation
 
@@ -25,7 +25,7 @@ if __debug__:
     from mvpa2.base import debug
     import time as time
 
-__all__ = [ "M1NNSearchlight", 'sphere_m1nnsearchlight' ]
+__all__ = [ "M1NNSearchlight", 'sphere_m1nnsearchlight', 'disk_m1nnsearchlight' ]
 
 class M1NNSearchlight(SimpleStatBaseSearchlight):
     """Efficient implementation of Mean-Nearest-Neighbor `Searchlight`.
@@ -225,6 +225,54 @@ def sphere_m1nnsearchlight(knn, generator, radius=1, center_ids=None,
     """
     # build a matching query engine from the arguments
     kwa = {space: Sphere(radius)}
+    qe = IndexQueryEngine(**kwa)
+    # init the searchlight with the queryengine
+    return M1NNSearchlight(knn, generator, qe,
+                          roi_ids=center_ids, *args, **kwargs)
+
+
+@borrowkwargs(M1NNSearchlight, '__init__', exclude=['roi_ids', 'queryengine'])
+def sphere_m1nnsearchlight(knn, generator, radius=0.01, center_ids=None,
+                        coords=None, space='vertex_indices', *args, **kwargs):
+    """Creates a `M1NNSearchlight` to assess :term:`cross-validation`
+    classification performance of M1NN on all possible disks of a
+    certain size within a dataset.
+
+    The idea of taking advantage of naiveness of M1NN for the sake of
+    quick searchlight-ing stems from Francisco Pereira (paper under
+    review).
+
+    Parameters
+    ----------
+    radius : float
+      All features within this radius around the center will be part
+      of a disk.
+    center_ids : list of int
+      List of feature ids (not coordinates) the shall serve as disk
+      centers. By default all features will be used (it is passed
+      roi_ids argument for Searchlight).
+    coords : list of float
+      List of feature ids coordinates on the inflated surface.
+    space : str
+      Name of a feature attribute of the input dataset that defines the spatial
+      coordinates of all features.
+    **kwargs
+      In addition this class supports all keyword arguments of
+      :class:`~mvpa2.measures.nnsearchlight.M1NNSearchlight`.
+
+    Notes
+    -----
+    If any `BaseSearchlight` is used as `SensitivityAnalyzer` one has to make
+    sure that the specified scalar `Measure` returns large
+    (absolute) values for high sensitivities and small (absolute) values
+    for low sensitivities. Especially when using error functions usually
+    low values imply high performance and therefore high sensitivity.
+    This would in turn result in sensitivity maps that have low
+    (absolute) values indicating high sensitivities and this conflicts
+    with the intended behavior of a `SensitivityAnalyzer`.
+    """
+    # build a matching query engine from the arguments
+    kwa = {space: Disk(coords, radius)}
     qe = IndexQueryEngine(**kwa)
     # init the searchlight with the queryengine
     return M1NNSearchlight(knn, generator, qe,

--- a/mvpa2/measures/nnsearchlight.py
+++ b/mvpa2/measures/nnsearchlight.py
@@ -232,7 +232,7 @@ def sphere_m1nnsearchlight(knn, generator, radius=1, center_ids=None,
 
 
 @borrowkwargs(M1NNSearchlight, '__init__', exclude=['roi_ids', 'queryengine'])
-def sphere_m1nnsearchlight(knn, generator, radius=0.01, center_ids=None,
+def disk_m1nnsearchlight(knn, generator, radius=0.01, center_ids=None,
                         coords=None, space='vertex_indices', *args, **kwargs):
     """Creates a `M1NNSearchlight` to assess :term:`cross-validation`
     classification performance of M1NN on all possible disks of a

--- a/mvpa2/misc/neighborhood.py
+++ b/mvpa2/misc/neighborhood.py
@@ -346,22 +346,6 @@ class Disk(object):
 
     Use this if you want to obtain all the neighbors within a given
     radius from a vertex on a spherical surface mesh.
-
-    Examples
-    --------
-    Create a mesh Disk with a diameter that covers 1.0% of the equator of a
-    spherical surface mesh. A diameter of 50% implies that the disk covers half
-    the sphere.
-
-    >>> from nibabel import freesurfer as nf
-    >>> coords, faces = nf.read_geometry('lh.sphere')
-    >>> d = Disk(coords, diameter=0.01)
-    >>> d(coords[0])
-    [(19.331, -92.343, -33.150),
-     (18.998, -92.332, -33.373),
-     ...
-     (18.829, -92.887, -31.896),
-     (19.904, -92.579, -32.136)]
     """
 
     def __init__(self, coordinates, diameter=0.01):

--- a/mvpa2/misc/neighborhood.py
+++ b/mvpa2/misc/neighborhood.py
@@ -341,6 +341,98 @@ class HollowSphere(Sphere):
         return np.vstack([np.zeros(ndim,dtype='int'),res]) if self.include_center else res
 
 
+class Disk(object):
+    """Mesh Disk
+
+    Use this if you want to obtain all the neighbors within a given
+    radius from a vertex on the freesurfer surface mesh.
+
+    Examples
+    --------
+    Missing...
+    """
+
+    def __init__(self, coordinate, radius=0.01, sphere_radius=100.0):
+        """ Initialize the Disk
+
+        Parameters
+        ----------
+        coordinate: list
+          List of vertex coordinates in x, y, z.
+        radius: float
+          Radius of the 'disk'. If no `sphere_radius` is provided
+          radius will be effectively percentage of maximum radius
+        sphere_radius: float
+          Radius of the mesh sphere on which disk extend will be
+          computed
+
+        """
+        self._radius = radius
+        self._sphere_radius = sphere_radius
+        self._coordinate = coordinate
+
+    def __repr__(self, prefixes=None):
+        if prefixes is None:
+            prefixes = []
+        prefixes_ = ['radius=%r' % (self._radius,)] + prefixes
+        return "%s(%s)" % (self.__class__.__name__, ', '.join(prefixes_))
+
+    # Properties to assure R/O behavior for now
+    @property
+    def coordinate(self):
+        return self._coordinate
+
+    def radius(self):
+        return self._radius
+
+    def sphere_radius(self):
+        return self._sphere_radius
+
+    def __call__(self, coordinate):
+        """Get all mesh coordinates within disk diameter
+
+        Parameters
+        ----------
+        coordinate : sequence type of length 3 with integers
+
+        Returns
+        -------
+        Missing...
+
+        """
+        # type checking
+        coords = np.asanyarray(self._coordinate)
+
+        # find center id
+        center_id = [i for i, e in enumerate(coords)
+                  if e[0] == coordinate[0]
+                        and e[1] == coordinate[1]
+                        and e[2] == coordinate[2]][0]
+
+        # calculate radian value for percentage of maximal geodesic distance
+        disc_radian = np.pi * 100. * self._radius
+
+        # return center_id if radius is 0
+        if self._radius == 0:
+            return coordinate
+
+        # recenter sphere
+        centered_coordinate = coords - coords[center_id]
+
+        # calculate the distance of each vertex to the new center
+        distances = np.linalg.norm(centered_coordinate, axis=1)
+
+        # calculate max euclidean distance for a given geodeisc distance on sphere
+        #   This distance is the result of the following two equations:
+        #     ArcLenght = angle_between_vectors * radius -> solved for angle
+        #     EuclidDistance = 2 * radius * sin(angle/2) <- insert angle
+        max_distance = 2 * self._sphere_radius * \
+            np.sin((disc_radian / (2 * self._sphere_radius)))
+
+        coord_array = coords[np.where(distances <= max_distance)[0]]
+        return [tuple(x) for x in coord_array.tolist()]
+
+
 class QueryEngineInterface(object):
     """Very basic class for `QueryEngine`\s defining the interface
 

--- a/mvpa2/tests/test_neighborhood.py
+++ b/mvpa2/tests/test_neighborhood.py
@@ -181,7 +181,7 @@ def test_disk_basic():
     disk1 = ne.Disk(coordinates, 0)
     disk2 = ne.Disk(coordinates, 0.3)
     disk3 = ne.Disk(coordinates, 0.6)
-    assert_array_equal(disk1(coordinates[0]), [tuple(coordinates[0])])
+    assert_array_equal(disk1(coordinates[0]), coordinates[0])
     assert_array_equal(np.array(disk2(coordinates[0])), coordinates[:4])
     assert_array_equal(np.array(disk3(coordinates[0])),
                        np.vstack((coordinates[:9], coordinates[10])))

--- a/mvpa2/tests/test_neighborhood.py
+++ b/mvpa2/tests/test_neighborhood.py
@@ -170,11 +170,24 @@ def test_hollowsphere_include_center():
 
 
 def test_disk_basic():
-    coordinates = ... something something
-    hs = ne.Disk(1, 0)
-    assert_array_equal(hs((2, 1)),  [(1, 1), (2, 0), (2, 2), (3, 1)])
-    assert_array_equal(hs((1, )),   [(0,), (2,)])
-    assert_equal(len(hs((1,1,1))), 6)
+    coordinates = np.array([[ 12.64, -32.02,  93.88], [-52.71,  25.88,  80.93],
+                            [ 69.81,  20.30,  68.65], [-42.73, -70.45,  56.65],
+                            [-18.04,  88.13,  43.67], [ 76.40, -56.40,  31.32],
+                            [-97.73, -10.68,  18.29], [ 65.94,  74.91,   6.23],
+                            [  2.47, -99.77,  -6.30], [-67.78,  71.05, -18.86],
+                            [ 94.78,  -6.26, -31.25], [-70.43, -55.77, -43.91],
+                            [ 12.59,  81.80, -56.11], [ 39.77, -60.71, -68.78],
+                            [-56.46,  14.02, -81.33], [ 29.75,  16.56, -94.02]])
+    disk1 = ne.Disk(coordinates, 0)
+    disk2 = ne.Disk(coordinates, 0.3)
+    disk3 = ne.Disk(coordinates, 0.6)
+    assert_array_equal(disk1(coordinates[0]), [tuple(coordinates[0])])
+    assert_array_equal(np.array(disk2(coordinates[0])), coordinates[:4])
+    assert_array_equal(np.array(disk3(coordinates[0])),
+                       np.vstack((coordinates[:9], coordinates[10])))
+    assert_equal(len(disk1(coordinates[0])), 1)
+    assert_equal(len(disk2(coordinates[0])), 4)
+    assert_equal(len(disk3(coordinates[0])), 10)
 
 
 def test_query_engine():

--- a/mvpa2/tests/test_neighborhood.py
+++ b/mvpa2/tests/test_neighborhood.py
@@ -95,7 +95,7 @@ def test_sphere():
     if __debug__:
         # No float coordinates allowed for now...
         # XXX might like to change that ;)
-        # 
+        #
         assert_raises(ValueError, s, (1.0, 1.0, 1.0))
 
 
@@ -167,6 +167,14 @@ def test_hollowsphere_include_center():
     assert_array_equal(hs((2, 1)),  [(2,1), (1, 1), (2, 0), (2, 2), (3, 1)])
     assert_array_equal(hs((1, )),   [(1,), (0,), (2,)])
     assert_equal(len(hs((1,1,1))), 7)
+
+
+def test_disk_basic():
+    coordinates = ... something something
+    hs = ne.Disk(1, 0)
+    assert_array_equal(hs((2, 1)),  [(1, 1), (2, 0), (2, 2), (3, 1)])
+    assert_array_equal(hs((1, )),   [(0,), (2,)])
+    assert_equal(len(hs((1,1,1))), 6)
 
 
 def test_query_engine():

--- a/mvpa2/tests/test_searchlight.py
+++ b/mvpa2/tests/test_searchlight.py
@@ -24,17 +24,17 @@ from mvpa2.base import externals
 from mvpa2.mappers.base import ChainMapper
 from mvpa2.mappers.fx import mean_group_sample
 from mvpa2.clfs.transerror import ConfusionMatrix
-from mvpa2.measures.searchlight import sphere_searchlight, Searchlight
+from mvpa2.measures.searchlight import sphere_searchlight, Searchlight, disk_searchlight
 from mvpa2.measures.gnbsearchlight import sphere_gnbsearchlight, \
-     GNBSearchlight
+     GNBSearchlight, disk_gnbsearchlight
 from mvpa2.clfs.gnb import GNB
 from mvpa2.clfs.distance import one_minus_correlation
 
 from mvpa2.measures.nnsearchlight import sphere_m1nnsearchlight, \
-     M1NNSearchlight
+     M1NNSearchlight, disk_m1nnsearchlight
 from mvpa2.clfs.knn import kNN
 
-from mvpa2.misc.neighborhood import IndexQueryEngine, Sphere, HollowSphere, CachedQueryEngine
+from mvpa2.misc.neighborhood import IndexQueryEngine, Sphere, HollowSphere, Disk, CachedQueryEngine
 from mvpa2.misc.errorfx import corr_error, mean_match_accuracy
 from mvpa2.generators.partition import NFoldPartitioner, OddEvenPartitioner, CustomPartitioner
 from mvpa2.generators.splitters import Splitter
@@ -59,8 +59,10 @@ class SearchlightTests(unittest.TestCase):
         ok_(not 'nproc' in GNBSearchlight.__init__.__doc__)
         ok_(not 'nproc' in GNBSearchlight.__doc__)
         ok_(not 'nproc' in sphere_gnbsearchlight.__doc__)
+        ok_(not 'nproc' in disk_gnbsearchlight.__doc__)
         # but present elsewhere
         ok_('nproc' in sphere_searchlight.__doc__)
+        ok_('nproc' in disk_searchlight.__doc__)
         ok_('nproc' in Searchlight.__init__.__doc__)
 
     # https://github.com/PyMVPA/PyMVPA/issues/106
@@ -69,6 +71,14 @@ class SearchlightTests(unittest.TestCase):
         for sl in (sphere_searchlight,
                    sphere_gnbsearchlight,
                    sphere_m1nnsearchlight):
+            for kw in ('queryengine', 'qe'):
+                ok_(not kw in sl.__doc__,
+                    msg='There should be no %r in %s.__doc__' % (kw, sl))
+
+        # queryengine should not be provided to disk_* helpers
+        for sl in (disk_searchlight,
+                   disk_gnbsearchlight,
+                   disk_m1nnsearchlight):
             for kw in ('queryengine', 'qe'):
                 ok_(not kw in sl.__doc__,
                     msg='There should be no %r in %s.__doc__' % (kw, sl))


### PR DESCRIPTION
This PR adds the functionality to do searchlight analysis on the **surface mesh**, using a **disk** as searchlight.

I understand that PyMVPA has already some surface based searchlight functions, e.g. [`disc_surface_queryengine`](http://www.pymvpa.org/generated/mvpa2.misc.surfing.queryengine.disc_surface_queryengine.html) as described in [Oosterhof et al. (2011)](http://www.pymvpa.org/references.html#owd-11), but as far as I understand, none of them runs the serachlight on the surface mesh. The currently implemeneted approaches only use the surface to determine which voxels to use for the analysis.

Also, my approach is dependent on a sphercial surface mesh, as for example FreeSurfer's `lh.sphere`. The vertex coordinates of this spherical mesh are needed to compute the neighborhood properties and therefore determine if a vertex is in the searchlight disk.

It's my first function implementation to PyMVPA. My approach was to add the `disk_searchlight`  everywhere where I also found a `sphere_searchlight`. I tried to add some tests that hopefully should verify that the new [`Disk`](https://github.com/PyMVPA/PyMVPA/compare/master...miykael:disk_searchlight?expand=1#diff-104766b285ac58e13da2dd02f2064776) class works correctly.