### PR TITLE
[FIX] attempt to fix return of nan when convolving negative values with HRF

### DIFF
--- a/mvpa2/misc/fx.py
+++ b/mvpa2/misc/fx.py
@@ -34,10 +34,11 @@ def single_gamma_hrf(t, A=5.4, W=5.2, K=1.0):
     A = float(A)
     W = float(W)
     K = float(K)
-    return \
-        K * (t / A) ** ((A ** 2) / (W ** 2) * 8.0 * np.log(2.0)) \
-        * np.e ** ((t - A) / -((W ** 2) / A / 8.0 / np.log(2.0)))
 
+    res =  K * (t / A) + 0j ** ((A ** 2) / (W ** 2) * 8.0 * np.log(2.0)) \
+        * np.e ** ((t - A) / -((W + 0j ** 2) / A / 8.0 / np.log(2.0)))
+
+    return res.real
 
 ##REF: Name was automagically refactored
 def double_gamma_hrf(t, A1=5.4, W1=5.2, K1=1.0, A2=10.8, W2=7.35, K2=0.35):

--- a/mvpa2/tests/test_miscfx.py
+++ b/mvpa2/tests/test_miscfx.py
@@ -1,0 +1,28 @@
+from mvpa2.testing import *
+from mvpa2.misc.fx import single_gamma_hrf
+from mvpa2.misc.fx import double_gamma_hrf
+
+
+def test_negative_values_single_gamma_hrf():
+
+    # generate something with negative and/or positive values to convolve
+    x_neg = np.random.randint(-10, -5, (10))
+    x_pos = np.random.randint(5, 10, (10))
+    x_pn = np.random.randint(-5, 5, (10))
+    # define lambda function for convolution:
+    hrf_gen=lambda t: single_gamma_hrf(t)
+    hrf_double_gen=lambda t: double_gamma_hrf(t)
+    hrf_xntest = hrf_gen(x_neg)
+    hrf_xptest = hrf_gen(x_pos)
+    hrf_xpntest = hrf_gen(x_pn)
+    hrf_double_xntest = hrf_double_gen(x_neg)
+    hrf_double_xptest = hrf_double_gen(x_pos)
+    hrf_double_xpntest = hrf_double_gen(x_pn)
+
+    # this is a bit convoluted. It checks whether any element of the result is nan
+    assert_true(~[np.isnan(i) for i in hrf_xntest][0].any())
+    assert_true(~[np.isnan(i) for i in hrf_xptest][0].any())
+    assert_true(~[np.isnan(i) for i in hrf_xpntest][0].any())
+    assert_true(~[np.isnan(i) for i in hrf_double_xntest][0].any())
+    assert_true(~[np.isnan(i) for i in hrf_double_xptest][0].any())
+    assert_true(~[np.isnan(i) for i in hrf_double_xpntest][0].any())


### PR DESCRIPTION
This PR
- fixes issue related with the use of complex math in single_gamma_hrf() function
- implements a rudimentary unit test for it