### PR TITLE
[FIX]: First attempt to get a classifiers plot function also build confusion matrices from a subset of labels

### DIFF
--- a/mvpa2/clfs/transerror.py
+++ b/mvpa2/clfs/transerror.py
@@ -969,6 +969,10 @@ class ConfusionMatrix(SummaryStatistics):
                     v = None
                     if l is not None: v = labels_map_full[l]
                     labels_plot += [v]
+            elif (len(labels) != labels_order_filtered_set) and \
+                    all(isinstance(x, str) for x in labels_order_filtered_set):
+                # get those items in provided label parameter that correspond to the existing labels
+                labels_plot = [label for label in labels_order_filtered_set if label in labels]
             else:
                 raise ValueError, \
                       "Provided labels %s do not match set of known " \
@@ -984,10 +988,13 @@ class ConfusionMatrix(SummaryStatistics):
         NlabelsNN = len(non_empty)
         Nlabels = len(labels_plot)
 
-        if matrix.shape != (NlabelsNN, NlabelsNN):
-            raise ValueError, \
-                  "Number of labels %d doesn't correspond the size" + \
-                  " of a confusion matrix %s" % (NlabelsNN, matrix.shape)
+        # I believe this Error is superfluous -- or rather: wouldn't let
+        # subsets of matrices be printed.
+
+        #if matrix.shape != (NlabelsNN, NlabelsNN):
+        #    raise ValueError, \
+        #          "Number of labels %d doesn't correspond the size" + \
+        #          " of a confusion matrix %s" % (NlabelsNN, matrix.shape)
 
         confusionmatrix = np.zeros((Nlabels, Nlabels))
         mask = confusionmatrix.copy()

--- a/mvpa2/tests/test_transerror.py
+++ b/mvpa2/tests/test_transerror.py
@@ -673,6 +673,26 @@ class ErrorsTests(unittest.TestCase):
                                       cvnp[(np.array([0,1]), np.array([1,0]))])
 
 
+def test_plotting_subset():
+    """ smoketest to see whether plotting only a subset of existing labels blows"""
+
+    from mvpa2.misc.data_generators import normal_feature_dataset
+    from mvpa2.clfs.gnb import GNB
+    ds = normal_feature_dataset(nlabels=4)
+    clf = GNB()
+    cv = CrossValidation(
+        clf, NFoldPartitioner(),
+        errorfx=None,
+        enable_ca=['stats'])
+    res = cv(ds)
+    # get all labels
+    labels = cv.ca.stats.labels
+    cv.ca.stats.plot(labels=labels, numbers=True)
+    # get n-1 labels
+    labels = cv.ca.stats.labels[1:]
+    cv.ca.stats.plot(labels=labels, numbers=True)
+
+
 def test_confusion_as_node():
     from mvpa2.misc.data_generators import normal_feature_dataset
     from mvpa2.clfs.gnb import GNB


### PR DESCRIPTION
This PR:
- allows plotting of confusion matrices with a subset of labels of the original classification, if they are specified as strings within the ``labels`` parameter
- disables plot() from blowing up if the length of provided labels does not match the dimensions of the matrix
- add a small smoketest to see whether plotting of full or subsets of the labels blows up