### PR TITLE
BF: set affine to the one we know in map2nifti

### DIFF
--- a/mvpa2/datasets/mri.py
+++ b/mvpa2/datasets/mri.py
@@ -176,9 +176,8 @@ def map2nifti(dataset, data=None, imghdr=None, imgtype=None):
     if issubclass(imgtype, nibabel.spatialimages.SpatialImage) \
             and (imghdr is None or hasattr(imghdr, 'get_data_dtype')):
         # we can handle the desired image type and hdr with nibabel
-        # use of `None` for the affine should cause to pull it from
-        # the header
-        return imgtype(_get_xyzt_shaped(dsarray), None, imghdr)
+        imgaffine = getattr(dataset.a, 'imgaffine', None)
+        return imgtype(_get_xyzt_shaped(dsarray), imgaffine, imghdr)
     else:
         raise ValueError(
             "Got imgtype=%s and imghdr=%s -- cannot generate an Image"

--- a/mvpa2/tests/test_niftidataset.py
+++ b/mvpa2/tests/test_niftidataset.py
@@ -125,6 +125,9 @@ def test_nifti_mapper(filename):
     vol = map2nifti(data, np.ones((294912,), dtype='int16'))
     assert_equal(vol.shape, (128, 96, 24))
     assert_true((vol.get_data() == 1).all())
+    # We record the affine we know
+    assert_array_equal(vol.affine, data.a.imgaffine)
+
     # test mapping of the dataset
     vol = map2nifti(data)
     assert_equal(vol.shape, (128, 96, 24, 2))


### PR DESCRIPTION
Original comment hinted that it was supposed to be set by nibabel if provided
affine is None.  I have tested in precise docker image with nibabel 1.1.0 (2011ish)
and it (already) was not the case.  So better to set it explicitly and test for
that in the tests.  Thanks @ddwagner for the report and analysis!

Closes #599