### PR TITLE
ENH: fsl.load_stats to load cope/zstat etc from .feat directories

### DIFF
--- a/mvpa2/misc/fsl/base.py
+++ b/mvpa2/misc/fsl/base.py
@@ -308,14 +308,23 @@ def read_fsl_design(fsf_file):
     return fsl
 
 
-def load_stats(feat_dir, stat="cope", suffix='.nii.gz', **kwargs):
+def load_stats(feat_dir, stats=["cope"], suffix='.nii.gz', **kwargs):
     """Load results of FSL stat analyses from .feat directory
 
     Parameters
     ----------
+    feat_dir: str
+      Path to the .feat directory which contains design.fsf and stats/
+    stats: list, optional
+      Which statistics to load.  Correspond to the filename prefixes under stats/
+    suffix: str, optional
+      If FSLOUTPUTTYPE was not set to NIFTI_GZ specify what extension to take
     kwargs: dict
       To be passed into fmri_dataset
     """
+    from mvpa2.base.dataset import vstack
+    from mvpa2.datasets.mri import fmri_dataset
+
     design = read_fsl_design(op.join(feat_dir, 'design.fsf'))
     ncon_orig = design['fmri(ncon_orig)']
     ncon_real = design['fmri(ncon_real)']
@@ -327,16 +336,22 @@ def load_stats(feat_dir, stat="cope", suffix='.nii.gz', **kwargs):
 
     statdir = op.join(feat_dir, 'stats')
     con_indexes = list(range(1, ncon_real + 1))
-    files = [
-        op.join(statdir, '%s%d%s' % (stat, con, suffix))
-        for con in con_indexes
-    ]
     targets = [
         design['fmri(conname_real.%d)' % con]
         for con in con_indexes
     ]
-    from mvpa2.datasets.mri import fmri_dataset
-    ds = fmri_dataset(files, targets=targets, **kwargs)
-    ds.sa['contrast_index'] = con_indexes
-    ds.sa['stat'] = [stat] * len(con_indexes)
-    return ds
+    dss = []
+    for stat in stats:
+        files = [
+            op.join(statdir, '%s%d%s' % (stat, con, suffix))
+            for con in con_indexes
+        ]
+        ds = fmri_dataset(files, targets=targets, **kwargs)
+        ds.sa['indexes'] = con_indexes
+        ds.sa['stats'] = [stat] * len(con_indexes)
+        # Remove any sa which relates to time -- there is none left
+        for a in ds.sa.keys():
+            if a.startswith('time_'):
+                ds.sa.pop(a)
+        dss.append(ds)
+    return vstack(dss)


### PR DESCRIPTION
- assigns `targets` to correspond to description of each contrast
- assigns `indexes` to the index of the contrast as known to FSL
- can take keyword args to pass into `fmri_dataset`
- removes any `time_` sa upon loading
- can load arbitrary set of stats, by default only "cope" is loaded

Example:
```shell
openfmri/ds000107[tags/1.0.0^0]sub026/model/model001/task001_run001.feat
$> PYTHONPATH=/home/yoh/proj/pymvpa/pymvpa python -c 'from mvpa2.misc.fsl import load_stats; print(load_stats(".", ["cope", "tstat"]))'
... pruned irrelevant warnings ...
 * Please note: warnings are printed only once, but underlying problem might occur many times *
<Dataset: 14x143360@float32, <sa: indexes,stats,targets>, <fa: voxel_indices>>
```

TODOs:
- [ ] test(s)
- [ ] remove restriction for having real = orig, @yarikoptic just forgot the details already

Optional TODOs:
- [ ] autodetection of the file extension. ATM defaults to .nii.gz and has an option to override