### PR TITLE
BF: AttributeMap -- consider only int (+unsigned) and float to be numeric labels

### DIFF
--- a/mvpa2/misc/attrmap.py
+++ b/mvpa2/misc/attrmap.py
@@ -150,7 +150,7 @@ class AttributeMap(object):
         attr = np.asanyarray(attr)
 
         # no mapping if already numeric
-        if not np.issubdtype(attr.dtype, str) and not self.mapnumeric:
+        if attr.dtype.kind in 'iuf' and not self.mapnumeric:
             return attr
 
         if self._nmap is None:

--- a/mvpa2/misc/data_generators.py
+++ b/mvpa2/misc/data_generators.py
@@ -124,7 +124,7 @@ def normal_feature_dataset(perlabel=50, nlabels=2, nfeatures=4, nchunks=5,
         # bring it 'under 1', since otherwise some classifiers have difficulties
         # during optimization
         data = 1.0 / (np.max(np.abs(data))) * data
-    labels = np.concatenate([np.repeat('L%d' % i, perlabel)
+    labels = np.concatenate([np.repeat(u'L%d' % i, perlabel)
                              for i in range(nlabels)])
     chunks = np.concatenate([np.repeat(range(nchunks),
                                        perlabel // nchunks)

--- a/mvpa2/tests/test_hdf5.py
+++ b/mvpa2/tests/test_hdf5.py
@@ -323,6 +323,12 @@ _numpy_objs = [
     np.array(list('abcdef')),
     np.array("string"),
     np.array(u"ы"),
+    # not an array but just an instance of that type
+    np.float64(1),
+    # problematic prior h5py 2.9.0
+    np.float128(1),
+    np.unicode(u"ы"),
+    np.unicode_(u"ы"),
   ] \
   + _unicode_arrays \
   + [a[:, ::2] for a in _unicode_arrays]
@@ -339,7 +345,11 @@ _numpy_objs += [
 def test_save_load_python_objs(fname, obj):
     """Test saving objects of various types
     """
-    # print obj, obj.shape
+    # try:
+    #     print type(obj), " ",
+    #     print obj # , obj.shape
+    # except Exception as e:
+    #     print e
     # save/reload
     try:
         h5save(fname, obj)


### PR DESCRIPTION
This generalizes the logic and thus unicode labels would also be mapped,
as well as any other odd type.  Use unicode labels for normal_feature_dataset

Closes #604 