### PR TITLE
Set division in HalfPartitioner to floor division for Python 3 compat

### DIFF
--- a/mvpa2/generators/partition.py
+++ b/mvpa2/generators/partition.py
@@ -319,8 +319,8 @@ class HalfPartitioner(Partitioner):
         list of tuples (None, list of int)
           2 items: first half of samples into 1st split
         """
-        return [(None, uniqueattrs[:len(uniqueattrs)/2]),
-                (None, uniqueattrs[len(uniqueattrs)/2:])]
+        return [(None, uniqueattrs[:len(uniqueattrs)//2]),
+                (None, uniqueattrs[len(uniqueattrs)//2:])]
 
 
 


### PR DESCRIPTION
Running through the tutorial with students noticed that the HalfPartitioner throws an error in Python3 but not 2. The culprit is the change to division in Python 3 that now returns float instead of int. Integer divsion (//) works in Python 2 so shouldn't break compatibility.