### PR TITLE
A variety of fixes to make target pairs consistently object array of tuples with (neg, pos) targets

### DIFF
--- a/mvpa2/clfs/gnb.py
+++ b/mvpa2/clfs/gnb.py
@@ -121,6 +121,11 @@ class GNB(Classifier):
         # Define internal state of classifier
         self._norm_weight = None
 
+        # Add 'has_sensitivity' tag if classifier is linear
+        if self.params.common_variance:
+            self.__tags__ = self.__tags__ + ['has_sensitivity']
+
+
     def _get_priors(self, nlabels, nsamples, nsamples_per_class):
         """Return prior probabilities given data
         """
@@ -203,11 +208,7 @@ class GNB(Classifier):
         else:
             self._norm_weight = 1.0/np.sqrt(2*np.pi*variances)
 
-        # Add 'has_sensitivity' tag if classifier is linear
-        if params.common_variance \
-            and 'has_sensitivity' not in self.__tags__:
-            self.__tags__ += ['has_sensitivity']
-
+        assert params.common_variance == ('has_sensitivity' in self.__tags__)
 
         if __debug__ and 'GNB' in debug.active:
             debug('GNB', "training finished on data.shape=%s " % (X.shape, )
@@ -222,9 +223,6 @@ class GNB(Classifier):
         self.ulabels = None
         self.priors = None
         super(GNB, self)._untrain()
-        # Remove 'has_sensitivity' tag
-        if 'has_sensitivity' in self.__tags__:
-            self.__tags__.remove('has_sensitivity')
 
 
     @accepts_dataset_as_samples

--- a/mvpa2/clfs/gnb.py
+++ b/mvpa2/clfs/gnb.py
@@ -25,6 +25,7 @@ import numpy as np
 from numpy import ones, zeros, sum, abs, isfinite, dot
 from mvpa2.base import warning, externals
 from mvpa2.clfs.base import Classifier, accepts_dataset_as_samples
+from mvpa2.base.types import asobjarray
 from mvpa2.base.param import Parameter
 from mvpa2.base.state import ConditionalAttribute
 from mvpa2.base.constraints import EnsureChoice
@@ -316,7 +317,7 @@ class GNBWeights(Sensitivity):
     on a given `Dataset`.
     """
 
-    _LEGAL_CLFS = [ GNB ]
+    _LEGAL_CLFS = [GNB]
 
     def _call(self, dataset):
         # for a binary decision between two labels, for all pairwise combinations of labels in
@@ -332,16 +333,26 @@ class GNBWeights(Sensitivity):
         pairs = list(itertools.combinations(range(len(clf.ulabels)), 2))
 
         weights = np.zeros([len(pairs), nfeat])
-        # do not compute sensitivity for features with variance 0 as this would implicate
-        # a division by zero
-        nonzero_vars = clf.variances!=0
+        # do not compute sensitivity for features with variance 0 as this would
+        # implicate a division by zero
+        nonzero_vars = clf.variances != 0
+        assert clf.params.common_variance
+        nonzero_vars0 = nonzero_vars[0, :]
         for idx, pair in enumerate(pairs):
-            weights[idx, nonzero_vars[0, :]] = (means[pair[0], nonzero_vars[0, :]] -
-                                                  means[pair[1], nonzero_vars[0, :]]) / \
-                                                 clf.variances[pair[0], nonzero_vars[0, :]]
+            # two-class sensitivity for (L0, L1) assumes that L1 is the
+            # "positive one"
+            weights[idx, nonzero_vars0] = (means[pair[1], nonzero_vars0] -
+                                           means[pair[0], nonzero_vars0]) / \
+                                          clf.variances[pair[0], nonzero_vars0]
 
         # put everything into a Dataset
-        ds = Dataset(weights,
-                     sa={clf.get_space(): [(clf.ulabels[p1], clf.ulabels[p2]) for p1, p2 in pairs]})
+        ds = Dataset(
+            weights,
+            sa={
+                clf.get_space(): asobjarray([
+                    (clf.ulabels[p1], clf.ulabels[p2]) for p1, p2 in pairs]
+                )
+            }
+        )
         return ds
 

--- a/mvpa2/clfs/libsvmc/sens.py
+++ b/mvpa2/clfs/libsvmc/sens.py
@@ -170,9 +170,11 @@ class LinearSVMWeights(Sensitivity):
             # and we should have prepared the labels
             assert(sens_labels is not None)
 
+            # Assure that our tuples for pairs do not get converted to list
+            if isinstance(sens_labels[0], tuple):
+                sens_labels = asobjarray(sens_labels)
+
             if len(clf._attrmap):
-                if isinstance(sens_labels[0], tuple):
-                    sens_labels = asobjarray(sens_labels)
                 sens_labels = clf._attrmap.to_literal(sens_labels, recurse=True)
 
             # NOTE: `weights` is already and always 2D

--- a/mvpa2/clfs/meta.py
+++ b/mvpa2/clfs/meta.py
@@ -1158,7 +1158,7 @@ class MulticlassClassifier(CombinedClassifier):
         """
         # construct binary classifiers
         biclfs = []
-        for poslabels, neglabels in self._get_binary_pairs(dataset):
+        for neglabels, poslabels in self._get_binary_pairs(dataset):
             biclfs.append(
                 BinaryClassifier(self.__clf.clone(),
                                  poslabels=poslabels,

--- a/mvpa2/clfs/meta.py
+++ b/mvpa2/clfs/meta.py
@@ -1187,10 +1187,14 @@ class MulticlassClassifier(CombinedClassifier):
 
             # for consistency -- place into object array of tuples
             # (Sensitivity analyzers already do the same)
-            # NOTE from archaeological expedition: here we place neglabels first
-            #      although everywhere else poslabels seems to be coming first!
-            pairs = zip(np.array([np.squeeze(clf.neglabels) for clf in self.clfs]).tolist(),
-                        np.array([np.squeeze(clf.poslabels) for clf in self.clfs]).tolist())
+            # NOTE from archaeological expedition:
+            #   although we specify poslabels in constructor first, here we
+            #   place neglabels first since that is how we treat pairs e.g.
+            #   in sensitivities -- from neg (or 0) to positive (or 1)
+            pairs = zip(
+                np.array([np.squeeze(clf.neglabels) for clf in self.clfs]).tolist(),
+                np.array([np.squeeze(clf.poslabels) for clf in self.clfs]).tolist()
+            )
             ca.raw_predictions_ds = raw_predictions_ds = \
                 Dataset(np.array(raw_predictions).T,
                         fa={self.space: asobjarray(pairs)})

--- a/mvpa2/datasets/base.py
+++ b/mvpa2/datasets/base.py
@@ -87,7 +87,7 @@ class Dataset(AttrDataset):
 
         Parameters
         ----------
-        sa, fa : dict, optional
+        sadict, fadict : dict, optional
           Dictionaries describing selection for samples/features
           correspondingly.
         strict : bool, optional

--- a/mvpa2/mappers/fx.py
+++ b/mvpa2/mappers/fx.py
@@ -15,6 +15,7 @@ import inspect
 
 from mvpa2.base import warning
 from mvpa2.base.node import Node
+from mvpa2.base.types import asobjarray
 from mvpa2.base.param import Parameter
 from mvpa2.base.constraints import *
 from mvpa2.datasets import Dataset
@@ -511,7 +512,13 @@ def _uniquemerge2literal(attrs):
         if isinstance(attrs[0], basestring):
             # do not try to disassemble sequences of strings
             raise TypeError
-        unq = [np.array(u) for u in set([tuple(p) for p in attrs])]
+        uvalues = set(map(tuple, attrs))
+        # if we were provided array of object type, most likely because
+        # we had tuples or other objects, we must produce also object array
+        if isinstance(attrs, np.ndarray) and attrs.dtype == 'O':
+            unq = asobjarray(list(uvalues))
+        else:
+            unq = list(map(np.array, uvalues))
     except TypeError:
         # either no 2d-iterable...
         try:

--- a/mvpa2/support/_emp_null.py
+++ b/mvpa2/support/_emp_null.py
@@ -236,11 +236,16 @@ class ENN(object):
         step = 3.5*np.std(self.x)/np.exp(np.log(self.n)/3)
         bins = int(max(10, (self.x.max() - self.x.min())/step))
         hist, ledge = np.histogram(x, bins=bins)
-        step = ledge[1]-ledge[0]
+        # I think there was a change in some numpy version on what to return
+        assert len(ledge) in (bins, bins + 1)
+        if len(ledge) == bins + 1:
+            # we are interested in left edges
+            ledge = ledge[:bins]
+        step = ledge[1] - ledge[0]
         medge = ledge + 0.5*step
-    
+
         # remove null bins
-        whist = hist>0
+        whist = hist > 0
         hist = hist[whist]
         medge = medge[whist]
         hist = hist.astype('f')

--- a/mvpa2/tests/test_datameasure.py
+++ b/mvpa2/tests/test_datameasure.py
@@ -175,7 +175,8 @@ class SensitivityAnalysersTests(unittest.TestCase):
             # is expected to suck in general
             return
 
-        if cfg.getboolean('tests', 'labile', default='yes'):
+        #if cfg.getboolean('tests', 'labile', default='yes'):
+        if True:
             for conf_matrix in [sana.clf.ca.training_stats] \
                               + sana.clf.ca.stats.matrices:
                 self.assertTrue(
@@ -198,7 +199,8 @@ class SensitivityAnalysersTests(unittest.TestCase):
         selected = FixedNElementTailSelector(
             len(ds.a.bogus_features))(sensgm.samples[0])
 
-        if cfg.getboolean('tests', 'labile', default='yes'):
+        #if cfg.getboolean('tests', 'labile', default='yes'):
+        if True:
 
             self.assertEqual(
                 set(selected), set(ds.a.nonbogus_features),

--- a/mvpa2/tests/test_datameasure.py
+++ b/mvpa2/tests/test_datameasure.py
@@ -215,9 +215,13 @@ class SensitivityAnalysersTests(unittest.TestCase):
                 lndim = labels1.ndim
                 label = labels1[0]      # current label
 
-                # XXX whole lndim comparison should be gone after
-                #     things get fixed and we arrive here with a tuple!
-                if lndim == 1: # just a single label
+                # There should be either one per class, or array of tuples
+                # for pairs
+                assert lndim == 1
+
+                # A single label -  e.g. in the case of SMLR which provides
+                # sensitivity per class, and not a tuple
+                if not isinstance(label, tuple):
                     self.assertTrue(label in ulabels)
 
                     ilabel_all = np.where(ds.fa.nonbogus_targets == label)[0]
@@ -230,7 +234,8 @@ class SensitivityAnalysersTests(unittest.TestCase):
                         "Maximal sensitivity for %s was found in %i whenever"
                         " original feature was %i for nonbogus features %s"
                         % (labels1, maxsensi, ilabel, ds.a.nonbogus_features))
-                elif lndim == 2 and labels1.shape[1] == 2: # pair of labels
+                else:  # pairs!
+                    assert_equal(len(label), 2)
                     # we should have highest (in abs) coefficients in
                     # those two labels
                     maxsensi2 = np.argsort(np.abs(sens1))[0][-2:]
@@ -256,11 +261,6 @@ class SensitivityAnalysersTests(unittest.TestCase):
                     self.assertTrue(sens1.samples[0, ilabel2[1]] > 0,
                         "With %i classes in pair %s got feature %i for %r <= 0"
                         % (nlabels, label, ilabel2[1], label[1]))
-                else:
-                    # yoh could be wrong at this assumption... time will show
-                    self.fail("Got unknown number labels per sensitivity: %s."
-                              " Should be either a single label or a pair"
-                              % labels1)
 
 
     @sweepargs(clf=clfswh['has_sensitivity'])

--- a/mvpa2/tests/test_datameasure.py
+++ b/mvpa2/tests/test_datameasure.py
@@ -119,7 +119,7 @@ class SensitivityAnalysersTests(unittest.TestCase):
         sens = sana(ds)
         assert('nonbogus_targets' in sens.fa) # were they passsed?
         # TODO: those few do not expose biases
-        if not len(set(clf.__tags__).intersection(('lars', 'glmnet', 'gpr'))):
+        if not len(set(clf.__tags__).intersection(('lars', 'glmnet', 'gpr', 'gnb'))):
             assert('biases' in sens.sa)
             # print sens.sa.biases
         # It should return either ...

--- a/mvpa2/tests/test_fxmapper.py
+++ b/mvpa2/tests/test_fxmapper.py
@@ -16,6 +16,9 @@ import numpy as np
 from mvpa2.mappers.fx import *
 from mvpa2.datasets.base import dataset_wizard, Dataset
 
+from mvpa2.base.types import asobjarray
+from mvpa2.mappers.fx import _uniquemerge2literal as u2l
+
 from mvpa2.testing.tools import *
 
 
@@ -237,14 +240,15 @@ def test_fx_native_calls(f):
 
 
 def test_uniquemerge2literal():
-    from mvpa2.mappers.fx import _uniquemerge2literal
-    assert_equal(_uniquemerge2literal(range(3)), ['0+1+2'])
-    assert_equal(_uniquemerge2literal(
+    assert_equal(u2l(range(3)), ['0+1+2'])
+    assert_equal(u2l(
         np.arange(6).reshape(2, 3)), ['[0 1 2]+[3 4 5]'])
-    assert_array_equal(_uniquemerge2literal([[2, 3, 4]]), [[2, 3, 4]])
-    assert_array_equal(_uniquemerge2literal([[2, 3, 4], [2, 3, 4]]), [[2, 3, 4]])
-    assert_equal(_uniquemerge2literal([2, 2, 2]), [2])
-    assert_array_equal(_uniquemerge2literal(['L1', 'L1']), ['L1'])
+    assert_array_equal(u2l([[2, 3, 4]]), [[2, 3, 4]])
+    assert_array_equal(u2l([[2, 3, 4], [2, 3, 4]]), [[2, 3, 4]])
+    assert_equal(u2l([2, 2, 2]), [2])
+    assert_array_equal(u2l(['L1', 'L1']), ['L1'])
+    # we should not loose our precious "tuples"
+    assert_equal(u2l(asobjarray([('1', '0'), ('1', '0')])), asobjarray([('1', '0')]))
 
 
 def test_bin_prop_ci():

--- a/mvpa2/tests/test_gnb.py
+++ b/mvpa2/tests/test_gnb.py
@@ -90,10 +90,7 @@ def test_gnb_sensitivities():
     assert_equal(sens.T[0], ('L0', 'L1'))
     assert_true(all(sens.samples[:, 3] == 0))
 
-    # test whether tagging and untagging works
-    assert 'has_sensitivity' in gnb.__tags__
     gnb.untrain()
-    assert 'has_sensitivity' not in gnb.__tags__
 
     # test whether content of sensitivities makes rough sense
     # First feature has information only about L0, so it would be of

--- a/mvpa2/tests/test_gnb.py
+++ b/mvpa2/tests/test_gnb.py
@@ -74,7 +74,7 @@ def test_gnb_sensitivities():
                                 nlabels=3,
                                 nfeatures=5,
                                 nchunks=4,
-                                snr=10,
+                                snr=20,
                                 nonbogus_features=[0, 1, 2]
                                 )
 
@@ -83,9 +83,11 @@ def test_gnb_sensitivities():
     assert_equal(s.shape, (((len(ds.uniquetargets) * (len(ds.uniquetargets) - 1))/2), ds.nfeatures))
     # test zero variance case
     # set variance of feature to zero
-    ds.samples[:,3]=0.3
+    ds.samples[:, 3] = 0.3
     s_zerovar = gnb.get_sensitivity_analyzer()
     sens = s_zerovar(ds)
+    assert_equal(sens.T.dtype, 'O')  # we store pairs
+    assert_equal(sens.T[0], ('L0', 'L1'))
     assert_true(all(sens.samples[:, 3] == 0))
 
     # test whether tagging and untagging works
@@ -94,8 +96,18 @@ def test_gnb_sensitivities():
     assert 'has_sensitivity' not in gnb.__tags__
 
     # test whether content of sensitivities makes rough sense
-    # e.g.: sensitivity of first feature should be larger than of bogus last feature
-    assert_true(abs(sens.samples[i, 0]) > abs(sens.samples[i, 4]) for i in range(np.shape(sens.samples)[0]))
+    # First feature has information only about L0, so it would be of
+    # no use for L1 -vs- L2 classification, so we will go through each pair
+    # and make sure that signs etc all correct for each pair.
+    # This in principle should be a generic test for multiclass sensitivities
+    abssens = abs(sens.samples)
+    for (t1, t2), t1t2sens in zip(sens.T, sens.samples):
+        # go from literal L1 to 1, L0 to 0 - corresponds to feature
+        i1 = int(t1[1])
+        i2 = int(t2[1])
+        assert t1t2sens[i1] < 0
+        assert t1t2sens[i2] > 0
+        assert t1t2sens[i2] > t1t2sens[4]
 
 
 def suite():  # pragma: no cover

--- a/mvpa2/tests/test_multiclf.py
+++ b/mvpa2/tests/test_multiclf.py
@@ -22,6 +22,7 @@ from mvpa2.base.dataset import vstack
 from mvpa2.generators.partition import NFoldPartitioner, OddEvenPartitioner
 from mvpa2.generators.splitters import Splitter
 
+from mvpa2.clfs.gnb import GNB
 from mvpa2.clfs.meta import CombinedClassifier, \
      BinaryClassifier, MulticlassClassifier, \
      MaximalVote
@@ -219,11 +220,12 @@ def test_multiclass_without_combiner():
             assert_equal(len(cm.sets), len(ds.UC))
 
 
-def test_multiclass_without_combiner_sens():
-    from mvpa2.clfs.gnb import GNB
-    # TODO: its sensitivity differs between clf and mclf
-    # clf = GNB(common_variance=True)
-    clf = LinearCSVMC(C=1)
+# Sweep through some representative interesting classifiers
+@sweepargs(clf=[
+    LinearCSVMC(C=1),
+    GNB(common_variance=True),
+])
+def test_multiclass_without_combiner_sens(clf):
     ds = datasets['uni3small'].copy()
     # do the clone since later we will compare sensitivities and need it
     # independently trained etc
@@ -233,7 +235,7 @@ def test_multiclass_without_combiner_sens():
     #    Multiclass.clfs -> [BinaryClassifier] -> clf
     # where BinaryClassifier's estimates are binarized.
     # Let's also check that we are getting sensitivities correctly.
-    # With addition of MulticlassClassifierSensitivity we managed to break
+    # With addition of MulticlassClassifierSensitivityAnalyzer we managed to break
     # it and none tests picked it up, so here we will test that sensitivities
     # are computed and labeled correctly
 

--- a/mvpa2/tests/test_multiclf.py
+++ b/mvpa2/tests/test_multiclf.py
@@ -209,7 +209,7 @@ def test_multiclass_without_combiner():
         # we must have received a dictionary per each pair
         training_stats = mcv.ca.training_stats
         assert_equal(set(training_stats.keys()),
-                     set([('L1', 'L0'), ('L2', 'L1'), ('L2', 'L0')]))
+                     set([('L0', 'L1'), ('L0', 'L2'), ('L1', 'L2')]))
         for pair, cm in training_stats.iteritems():
             assert_array_equal(cm.labels, ds.UT)
             # we should have no predictions for absent label

--- a/mvpa2/tests/test_multiclf.py
+++ b/mvpa2/tests/test_multiclf.py
@@ -194,6 +194,7 @@ def test_multiclass_without_combiner():
     ds = datasets['uni3small'].copy()
     ds.sa['ids'] = np.arange(len(ds))
     mclf = MulticlassClassifier(clf, combiner=None)
+
     # without combining results at all
     mcv = CrossValidation(mclf, NFoldPartitioner(), errorfx=None)
     res = mcv(ds)
@@ -216,3 +217,80 @@ def test_multiclass_without_combiner():
             assert_array_equal(cm.stats['P'], len(ds))
             # and number of sets should be equal number of chunks here
             assert_equal(len(cm.sets), len(ds.UC))
+
+
+def test_multiclass_without_combiner_sens():
+    from mvpa2.clfs.gnb import GNB
+    # TODO: its sensitivity differs between clf and mclf
+    # clf = GNB(common_variance=True)
+    clf = LinearCSVMC(C=1)
+    ds = datasets['uni3small'].copy()
+    # do the clone since later we will compare sensitivities and need it
+    # independently trained etc
+    mclf = MulticlassClassifier(clf.clone(), combiner=None)
+
+    # We have lots of sandwiching
+    #    Multiclass.clfs -> [BinaryClassifier] -> clf
+    # where BinaryClassifier's estimates are binarized.
+    # Let's also check that we are getting sensitivities correctly.
+    # With addition of MulticlassClassifierSensitivity we managed to break
+    # it and none tests picked it up, so here we will test that sensitivities
+    # are computed and labeled correctly
+
+
+    # verify that all kinds of results on two classes are identical to the ones
+    # if obtained running it without MulticlassClassifier
+    # ds = ds[:, 0]  #  uncomment out to ease/speed up troubleshooting
+    ds2 = ds.select(sadict=dict(targets=['L1', 'L2']))
+    # we will train only on one chunk so we could get "realistic" (not just
+    # overfit) predictions
+    ds2_train = ds2.select(sadict=dict(chunks=ds.UC[:1]))
+
+    # also consider simpler BinaryClassifier to easier pin point the problem
+    # and be explicit about what is positive and what is negative label(s)
+    bclf = BinaryClassifier(clf.clone(), poslabels=['L2'], neglabels=['L1'])
+
+    predictions = []
+    clfs = [clf, bclf, mclf]
+    for c in clfs:
+        c.ca.enable('all')
+        c.train(ds2_train)
+        predictions.append(c.predict(ds2))
+    p1, bp1, mp1 = predictions
+
+    assert_equal(p1, bp1)
+
+    # ATM mclf.predict returns dataset (with fa.targets to list pairs of targets
+    # used I guess) while p1 is just a list.
+    def assert_list_equal_to_ds(l, ds):
+        assert_equal(ds.shape, (len(l), 1))
+        assert_array_equal(l, ds.samples[:, 0])
+    assert_list_equal_to_ds(p1, mp1)
+
+    # but if we look at sensitivities
+    s1, bs1, ms1 = [
+        c.get_sensitivity_analyzer()(ds2)
+        for c in clfs
+    ]
+    # Do ground checks for s1
+    nonbogus_target = ds2.fa.nonbogus_targets[0]
+
+    # if there was a feature with signal, we know what to expect!:
+    # such assignments are randomized, so we might not have signal in that
+    # single feature we chose to test with
+    if nonbogus_target and nonbogus_target in ds2.UT:
+        # that in the pair of labels it would be 2nd one if positive sensitivity
+        # or 1st one is negative
+        # with classifier we try (SVM) should be pairs of labels
+        assert isinstance(s1.T[0], tuple)
+        assert_equal(len(s1), 1)
+        assert_equal(s1.T[0][int(s1.samples[0, 0] > 0)], nonbogus_target)
+
+    # And in either case we could check that we are getting identical results!
+    # lrn_index is unique to ms1 and "ignore_sa" to assert_datasets_equal still
+    # compares for the keys to be present in both, so does not help
+    ms1.sa.pop('lrn_index')
+
+    assert_datasets_equal(s1, bs1)
+    # and here we get a "problem"!
+    assert_datasets_equal(s1, ms1)


### PR DESCRIPTION
- GNB had sensitivity negated
- make GNB `has_sensitivity` added in constructor so we discover/test it from the warehouse
- test that MulticlassClassifier's sensitivity would match the one produced by the classifier directly
  - make order of targets for BinaryClassifier also be (neg, pos)
- make libsvm's SVM produce tuples of pairs even when no attrmap was assigned (SG one was doing that already)
- more ... 