### PR TITLE
ENH(BK): prototype for get_contrasts to obtain contrasts for fit NiPy GLM model

### DIFF
--- a/mvpa2/base/externals.py
+++ b/mvpa2/base/externals.py
@@ -603,6 +603,7 @@ _KNOWN = {'libsvm': 'import mvpa2.clfs.libsvmc._svm as __; x=__.seq_to_svm_node'
           'reportlab': "__check('reportlab', 'Version')",
           'nose': "import nose as __",
           'pprocess': "__check('pprocess')",
+          'pandas': "__check('pandas')",
           'joblib': "__check('joblib')",
           'h5py': "__check_h5py()",
           'hdf5': "__check_h5py()",

--- a/mvpa2/datasets/miscfx.py
+++ b/mvpa2/datasets/miscfx.py
@@ -537,3 +537,39 @@ class SequenceStats(dict):
         pl.xlabel('Offset')
         pl.ylabel('Correlation Coefficient')
         pl.show()
+
+
+@datasetmethod
+def to_df(ds, sas=None, fas=None):
+    """Return pandas DataFrame corresponding to the dataset
+
+    Parameters
+    ----------
+    sas: list, optional
+      List of sample-attribute names to be used/returned to define rows index.
+    fas: list, optional
+      List of feature-attribute names to be used/returned to define rows index.
+
+    """
+    import pandas as pd
+
+    def col_to_index(col, col_abbrev, names):
+        """Collection to Pandas's index conversion
+
+        """
+        attrs = sorted(col.keys()) if names is None else names
+        if not attrs:
+            return None
+        return pd.MultiIndex.from_tuples(
+            # force convert to str for now since needs to be hashable
+            zip(*[map(str, col[a].value) for a in attrs]),
+            names=['%s.%s' % (col_abbrev, fa) for fa in attrs]
+        )
+
+    df = pd.DataFrame(
+        np.asanyarray(ds.samples),
+        columns=col_to_index(ds.fa, 'fa', names=fas)
+    )
+    # Ideally here should be leveled if chunks/targets present
+    df = df.set_index(col_to_index(ds.sa, 'sa', names=sas))
+    return df

--- a/mvpa2/tests/test_datasetfx.py
+++ b/mvpa2/tests/test_datasetfx.py
@@ -10,6 +10,7 @@
 
 import unittest
 from mvpa2.testing.tools import ok_, assert_equal, assert_array_equal, reseed_rng
+from mvpa2.testing import sweepargs, skip_if_no_external
 
 import numpy as np
 
@@ -20,6 +21,7 @@ from mvpa2.datasets.miscfx import remove_invariant_features, coarsen_chunks, \
 
 
 from mvpa2.misc.data_generators import normal_feature_dataset
+from mvpa2.testing.datasets import datasets
 
 class MiscDatasetFxTests(unittest.TestCase):
 
@@ -137,6 +139,12 @@ class MiscDatasetFxTests(unittest.TestCase):
             # Check if str works fine
             sr = str(r)
             # TODO: check the content
+
+    @sweepargs(ds=datasets.itervalues())
+    def test_to_df_smoke(self, ds):
+        skip_if_no_external('pandas')
+        df = ds.to_df()
+        print(df)
 
 
 


### PR DESCRIPTION
Decided to make into an independent helper although probably could be used/invoked as part of the `fit_event_hrf_model`

- [x] finish
- [x] test(s)

attn @adswa

Bonus bundle: `.to_df` `@datasetmethod` to convert any Dataset to pandas data frame for at least some humane display of the dataset.  `.a` are get ignored, and `.sa`, `.fa` establish index and columns correspondingly.  So for a quick view at your dataset, just e.g.
```
(Pdb) get_contrasts(evds, contrasts={'face-house': {'face': 1, 'house': -1}}).to_df()
fa.voxel_indices   [0 3 4]   [0 3 5]   [0 4 4]
sa.targets                                    
face-house       -2.948647  1.933818  5.084473
```
although some would come out quite more elaborate ;)
```
*(Pdb) p ds.to_df()
fa.voxel_indices                                                                                [0 3 4] [0 3 5] [0 4 4]
sa.chunks sa.run sa.run_time_coords sa.subj sa.targets   sa.task sa.time_coords sa.time_indices                        
0         1      0.0                1       rest         1       0.0            0                   145     162     530
                 2.5                1       rest         1       2.5            1                   153     165     538
                 5.0                1       rest         1       5.0            2                   138     164     537
                 7.5                1       rest         1       7.5            3                   140     175     532
                 10.0               1       rest         1       10.0           4                   147     173     519
                 12.5               1       rest         1       12.5           5                   135     180     523
                 15.0               1       scissors     1       15.0           6                   146     175     525
                 17.5               1       scissors     1       17.5           7                   140     160     539
                 20.0               1       scissors     1       20.0           8                   145     172     538
...
```