### PR TITLE
BLD: for travis, set language to java and use trusty as distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@
 # travis-ci; it uses virtualenvs, they do not have numpy, scipy, matplotlib,
 # and it is impractical to build them
 language: java
+dist: trusty
 cache:
   - apt
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@
 # travis-ci.org definition for PyMVPA build (based on nipype configuration
 # which in turn was based on nipy)
 #
-# We pretend to be erlang because we need can't use the python support in
+# We pretend to be java because we need can't use the python support in
 # travis-ci; it uses virtualenvs, they do not have numpy, scipy, matplotlib,
 # and it is impractical to build them
-language: erlang
+language: java
 cache:
   - apt
 env:

--- a/mvpa2/tests/test_giftidataset.py
+++ b/mvpa2/tests/test_giftidataset.py
@@ -269,7 +269,7 @@ def test_gifti_dataset_with_anatomical_surface(fn, format_, include_nodes):
     ds = _get_test_dataset(include_nodes)
 
     nsamples, nfeatures = ds.shape
-    vertices = np.random.normal(size=(nfeatures, 3))
+    vertices = np.round(np.random.normal(size=(nfeatures, 3)), decimals=5)
     faces = np.asarray([i + np.arange(3) for i in xrange(2 * nfeatures)]) % nfeatures
     surf = Surface(vertices, faces)
 


### PR DESCRIPTION
This PR tries to address recent travis build errors, which started at

https://travis-ci.org/PyMVPA/PyMVPA/builds/545881884

with commit 

https://github.com/PyMVPA/PyMVPA/commit/2617c4d8dfe3fbe9e53f8e703ea996ab937b5c8f

although the root cause of the failing tests is probably a change in the default Ubunto configuration used on travis rather than code changes in PyMVPA.