### PR TITLE
FIX import of skipif for newer versions of numpy

### DIFF
--- a/mvpa2/testing/tools.py
+++ b/mvpa2/testing/tools.py
@@ -78,7 +78,12 @@ from numpy.testing import (
     assert_array_almost_equal, assert_array_equal, assert_array_less,
     assert_string_equal)
 
-from numpy.testing.decorators import skipif
+try:
+    from numpy.testing.decorators import skipif
+except ModuleNotFoundError:
+    from numpy.testing import dec
+    skipif = dec.skipif
+
 
 def assert_array_lequal(x, y):
     assert_array_less(-y, -x)


### PR DESCRIPTION
Otherwise we get

```
In [1]: from mvpa2.suite import *
Failed to import duecredit due to No module named 'duecredit'
/Users/mvdoc/bin/anaconda3/lib/python3.7/site-packages/mvpa2/misc/surfing/volume_mask_dict.py:24: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
  from collections import Mapping
ds = niml/Users/mvdoc/bin/anaconda3/lib/python3.7/site-packages/nose/importer.py:12: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
  from imp import find_module, load_module, acquire_lock, release_lock
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
<ipython-input-1-f67f7356da91> in <module>
----> 1 from mvpa2.suite import *

~/bin/anaconda3/lib/python3.7/site-packages/mvpa2/suite.py in <module>
     63     # Some pieces do not demand scipy, but for now let's just do this way
     64     from mvpa2.algorithms.searchlight_hyperalignment import *
---> 65     from mvpa2.algorithms.connectivity_hyperalignment import *
     66     from mvpa2.algorithms.group_clusterthr import *
     67

~/bin/anaconda3/lib/python3.7/site-packages/mvpa2/algorithms/connectivity_hyperalignment.py in <module>
     34 from mvpa2.mappers.svd import SVDMapper
     35
---> 36 from mvpa2.measures.searchlight import Searchlight
     37 from mvpa2.measures.base import Measure
     38

~/bin/anaconda3/lib/python3.7/site-packages/mvpa2/measures/searchlight.py in <module>
     38
     39 from mvpa2.support.due import due, Doi
---> 40 from mvpa2.testing import on_osx
     41
     42

~/bin/anaconda3/lib/python3.7/site-packages/mvpa2/testing/__init__.py in <module>
     21     debug('INIT', 'mvpa2.testing')
     22
---> 23 from mvpa2.testing.tools import *
     24
     25 if __debug__:

~/bin/anaconda3/lib/python3.7/site-packages/mvpa2/testing/tools.py in <module>
     79     assert_string_equal)
     80
---> 81 from numpy.testing.decorators import skipif
     82
     83 def assert_array_lequal(x, y):

ModuleNotFoundError: No module named 'numpy.testing.decorators'
```