### PR TITLE
[DOC] fix broken link to NiBabel on starting page

### DIFF
--- a/doc/source/link_names.txt
+++ b/doc/source/link_names.txt
@@ -13,8 +13,8 @@
 .. _`Brain Imaging Center`: http://bic.berkeley.edu/
 .. _dipy: http://nipy.sourceforge.net/dipy
 .. _`dipy github`: http://github.com/Garyfallidis/dipy
-.. _nibabel: http://nipy.sourceforge.net/nibabel
-.. _NiBabel: http://nipy.sourceforge.net/nibabel
+.. _nibabel: http://nipy.org/nibabel
+.. _NiBabel: http://nipy.org/nibabel
 .. _dipy: http://nipy.sourceforge.net/dipy
 
 .. _Neuron: http://www.neuron.yale.edu/neuron

--- a/doc/source/link_names.txt
+++ b/doc/source/link_names.txt
@@ -14,6 +14,7 @@
 .. _dipy: http://nipy.sourceforge.net/dipy
 .. _`dipy github`: http://github.com/Garyfallidis/dipy
 .. _nibabel: http://nipy.sourceforge.net/nibabel
+.. _NiBabel: http://nipy.sourceforge.net/nibabel
 .. _dipy: http://nipy.sourceforge.net/dipy
 
 .. _Neuron: http://www.neuron.yale.edu/neuron


### PR DESCRIPTION
Link to NiBabel under "Similar or Related Projects" on http://www.pymvpa.org/index.html#id4 is broken.