### PR TITLE
docs: Fix a few typos

### DIFF
--- a/doc/examples/pylab_2d.py
+++ b/doc/examples/pylab_2d.py
@@ -113,7 +113,7 @@ for id, ds in datasets.iteritems():
         fig += 1
         pl.subplot(ny, nx, fig)
 
-        # select the clasifier
+        # select the classifier
         clf = clfs[c]
 
         # enable saving of the estimates used for the prediction

--- a/doc/source/datadb/forrestgump_audio.rst
+++ b/doc/source/datadb/forrestgump_audio.rst
@@ -32,7 +32,7 @@ Usage
 =====
 
 Detailed information on the nature of the dataset is given in the data
-descriptor. In order to faciliate re-use of this dataset a reference
+descriptor. In order to facilitate re-use of this dataset a reference
 implementation of a data access module has been made available at:
 
   https://github.com/hanke/gumpdata

--- a/mvpa2/mappers/mdp_adaptor.py
+++ b/mvpa2/mappers/mdp_adaptor.py
@@ -26,7 +26,7 @@ from mvpa2.misc.support import is_in_volume
 
 
 class MDPNodeMapper(Mapper):
-    """Mapper encapsulating an arbitray MDP node.
+    """Mapper encapsulating an arbitrary MDP node.
 
     This mapper wraps an MDP node and uses it for forward and reverse data
     mapping (reverse is only available if the underlying MDP node supports
@@ -219,7 +219,7 @@ class ICAMapper(MDPNodeMapper):
 
 
 class MDPFlowMapper(Mapper):
-    """Mapper encapsulating an arbitray MDP flow.
+    """Mapper encapsulating an arbitrary MDP flow.
 
     This mapper wraps an MDP flow and uses it for forward and reverse data
     mapping (reverse is only available if the underlying MDP flow supports

--- a/mvpa2/measures/base.py
+++ b/mvpa2/measures/base.py
@@ -551,7 +551,7 @@ class TransferMeasure(Measure):
 
     Upon calling a TransferMeasure instance with a dataset the input dataset
     is passed to a `Splitter` to will generate dataset subsets. The first
-    generated dataset is used to train an arbitray embedded `Measure. Once
+    generated dataset is used to train an arbitrary embedded `Measure. Once
     trained, the measure is then called with the second generated dataset
     and the result is returned.
     """

--- a/mvpa2/misc/surfing/volgeom.py
+++ b/mvpa2/misc/surfing/volgeom.py
@@ -625,7 +625,7 @@ class VolGeom(object):
             If a callable, it should be a a neighborhood function
             (like Sphere(..)) that can map a single voxel coordinate
             (represented as a triple of indices) to a list of voxel
-            coordinates that define the neighboorhood of that
+            coordinates that define the neighborhood of that
             coordinate. For example, Sphere(3) can be used to dilate the
             original mask by 3 voxels. If an int, then it uses
             Sphere(dilate) to dilate the mask. If set to None
@@ -705,7 +705,7 @@ class VolGeom(object):
             If a callable, it should be a a neighborhood function
             (like Sphere(..)) that can map a single voxel coordinate
             (represented as a triple of indices) to a list of voxel
-            coordinates that define the neighboorhood of that
+            coordinates that define the neighborhood of that
             coordinate. For example, Sphere(3) can be used to dilate the
             original mask by 3 voxels. If an int, then it uses
             Sphere(dilate) to dilate the mask. If set to None

--- a/mvpa2/support/nibabel/surf.py
+++ b/mvpa2/support/nibabel/surf.py
@@ -1427,7 +1427,7 @@ class Surface(object):
 
         # add border nodes to all low-res surface
         # this is a bit inefficient
-        # TODO optimize to consider neighboorhood
+        # TODO optimize to consider neighborhood
         for x_tuple in x_tuples:
             x_tuple2near_indices[x_tuple] = list(on_borders)
 
@@ -1501,7 +1501,7 @@ class Surface(object):
             node on the low-res surface
         '''
 
-        # the set of indidces that will serve as keys in high2high_in_low
+        # the set of indices that will serve as keys in high2high_in_low
         if highres_indices is None:
             highres_indices = np.arange(highres_surf.nvertices)
         highres_indices = set(highres_indices)
@@ -1869,7 +1869,7 @@ def get_sphere_left_right_mapping(surf_left, surf_right, eps=.001):
     l2r = {pivotL: pivotR}
     to_visit = nL[pivotL].keys()
 
-    # for each node (in the left hemispehre) still to visit, keep track of its
+    # for each node (in the left hemisphere) still to visit, keep track of its
     # 'parent'
     to_visit2source = dict(zip(to_visit, [pivotL] * len(to_visit)))
 
@@ -1995,7 +1995,7 @@ def generate_sphere(density=10):
     sphere: surf.Surface
         A sphere with d**2+2 vertices and 2*d**2 faces. Seen as the planet
         Earth, node 0 and 1 correspond to the north and south poles.
-        The remaining d**2 vertices are in d circles of latitute, each with
+        The remaining d**2 vertices are in d circles of latitude, each with
         d vertices in them.
     '''
 


### PR DESCRIPTION
There are small typos in:
- doc/examples/pylab_2d.py
- doc/source/datadb/forrestgump_audio.rst
- mvpa2/mappers/mdp_adaptor.py
- mvpa2/measures/base.py
- mvpa2/misc/surfing/volgeom.py
- mvpa2/support/nibabel/surf.py

Fixes:
- Should read `neighborhood` rather than `neighboorhood`.
- Should read `arbitrary` rather than `arbitray`.
- Should read `latitude` rather than `latitute`.
- Should read `indices` rather than `indidces`.
- Should read `hemisphere` rather than `hemispehre`.
- Should read `facilitate` rather than `faciliate`.
- Should read `classifier` rather than `clasifier`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md